### PR TITLE
refactor: transparent relay proxy — remove HTML rewriting

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -75,10 +75,11 @@ app.use(buildBrokerRouter(relayServer, sessions));
 // Inbound webhook forwarding: /u/:uuid/hooks/*
 // Accepts any HTTP method. Reads the raw body, forwards via the WebSocket tunnel
 // to the connected daemon, and streams the daemon's response back to the caller.
+// URL rewriting handled daemon-side — see dicode-core feat/transparent-relay-proxy
 app.all("/u/:uuid/hooks/*path", express.raw({ type: "*/*", limit: "5mb" }), (req, res) => {
   const uuid = req.params.uuid;
-  const pathSegments = req.params.path as string | string[];
-  const pathStr = Array.isArray(pathSegments) ? pathSegments.join("/") : pathSegments;
+  const pathParam = req.params.path;
+  const pathStr = Array.isArray(pathParam) ? pathParam.join("/") : pathParam;
   const hookPath = "/hooks/" + pathStr;
 
   if (!relayServer.hasClient(uuid)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,35 +72,6 @@ app.use(grantMiddleware);
 // Broker router
 app.use(buildBrokerRouter(relayServer, sessions));
 
-// Forward /u/:uuid/dicode.js to the daemon's webhook handler (serves the client SDK).
-app.get("/u/:uuid/dicode.js", (req, res) => {
-  const uuid = req.params.uuid;
-  if (!relayServer.hasClient(uuid)) {
-    res.status(502).json({ error: "daemon not connected" });
-    return;
-  }
-  relayServer
-    .forward(uuid, "GET", "/dicode.js", {}, Buffer.alloc(0))
-    .then((response) => {
-      res.status(response.status);
-      if (response.headers !== undefined) {
-        for (const [k, vals] of Object.entries(response.headers)) {
-          for (const v of vals) {
-            res.append(k, v);
-          }
-        }
-      }
-      if (response.body !== undefined && response.body !== "") {
-        res.send(Buffer.from(response.body, "base64"));
-      } else {
-        res.end();
-      }
-    })
-    .catch(() => {
-      res.status(504).json({ error: "forwarding failed or timed out" });
-    });
-});
-
 // Inbound webhook forwarding: /u/:uuid/hooks/*
 // Accepts any HTTP method. Reads the raw body, forwards via the WebSocket tunnel
 // to the connected daemon, and streams the daemon's response back to the caller.
@@ -137,32 +108,7 @@ app.all("/u/:uuid/hooks/*path", express.raw({ type: "*/*", limit: "5mb" }), (req
         }
       }
       if (response.body !== undefined && response.body !== "") {
-        const bodyBuf = Buffer.from(response.body, "base64");
-        // Rewrite absolute paths in HTML responses so assets load through the relay.
-        const ct = res.getHeader("content-type");
-        const isHtml = typeof ct === "string" && ct.includes("text/html");
-        if (isHtml) {
-          const relayPrefix = `/u/${uuid}`;
-          let html = bodyBuf.toString("utf8");
-          // <base href="/hooks/foo/"> → <base href="/u/<uuid>/hooks/foo/">
-          html = html.replace(
-            /(<base\s+href=")([^"]*")/i,
-            (_m, tag: string, href: string) => tag + relayPrefix + href,
-          );
-          // <script src="/dicode.js"> → <script src="/u/<uuid>/dicode.js">
-          html = html.replace(
-            /(<script\s+src=")(\/dicode\.js")/i,
-            (_m, tag: string, src: string) => tag + relayPrefix + src,
-          );
-          // <meta name="dicode-hook" content="/hooks/foo"> → content="/u/<uuid>/hooks/foo"
-          html = html.replace(
-            /(<meta\s+name="dicode-hook"\s+content=")([^"]*")/i,
-            (_m, tag: string, val: string) => tag + relayPrefix + val,
-          );
-          res.send(html);
-        } else {
-          res.send(bodyBuf);
-        }
+        res.send(Buffer.from(response.body, "base64"));
       } else {
         res.end();
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,8 +77,8 @@ app.use(buildBrokerRouter(relayServer, sessions));
 // to the connected daemon, and streams the daemon's response back to the caller.
 app.all("/u/:uuid/hooks/*path", express.raw({ type: "*/*", limit: "5mb" }), (req, res) => {
   const uuid = req.params.uuid;
-  const pathParam = req.params.path;
-  const pathStr = Array.isArray(pathParam) ? pathParam.join("/") : (pathParam ?? "");
+  const pathSegments = req.params.path as string | string[];
+  const pathStr = Array.isArray(pathSegments) ? pathSegments.join("/") : pathSegments;
   const hookPath = "/hooks/" + pathStr;
 
   if (!relayServer.hasClient(uuid)) {
@@ -100,14 +100,12 @@ app.all("/u/:uuid/hooks/*path", express.raw({ type: "*/*", limit: "5mb" }), (req
     .forward(uuid, req.method, hookPath, headers, body)
     .then((response) => {
       res.status(response.status);
-      if (response.headers !== undefined) {
-        for (const [k, vals] of Object.entries(response.headers)) {
-          for (const v of vals) {
-            res.append(k, v);
-          }
+      for (const [k, vals] of Object.entries(response.headers)) {
+        for (const v of vals) {
+          res.append(k, v);
         }
       }
-      if (response.body !== undefined && response.body !== "") {
+      if (response.body !== "") {
         res.send(Buffer.from(response.body, "base64"));
       } else {
         res.end();


### PR DESCRIPTION
## Summary

- Remove all HTML response body rewriting (base href, dicode.js script src, dicode-hook meta tag regex replacements)
- Remove the `/u/:uuid/dicode.js` special forwarding route
- The relay is now a completely transparent proxy — it never inspects or modifies response bodies
- Net change: **-55 lines**, 1 file

## Why

The previous approach (regex-replacing HTML attributes in response bodies) was fragile and unscalable — every new absolute path reference required a new regex. The daemon already has full context (its own UUID, the relay welcome URL) to handle URL rewriting itself.

## What moves where

URL rewriting responsibility moves to the daemon side (companion PR: dicode-ayo/dicode-core `feat/transparent-relay-proxy`):
- Relay client adds `X-Relay-Base: /u/<uuid>` header when forwarding requests to the local daemon
- Daemon's `injectDicodeSDK` reads that header and prefixes `<base href>`, `dicode-hook` meta, and `dicode.js` src
- Validation: `X-Relay-Base` must match `/u/[0-9a-f]{64}` — rejects malformed values

## Test plan

- [x] All 78 relay tests pass
- [x] TypeScript typecheck clean
- [x] Build succeeds (`npm run build`)
- [ ] Manual: webhook forwarding works through relay
- [ ] Manual: webhook UI tasks with assets load correctly after daemon-side PR lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)