### PR TITLE
feat(db): SQLite persistence layer for users, daemons, plans, hook usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,34 @@
 FROM node:25-alpine AS build
 WORKDIR /app
+# build-base + python3 are needed to compile the better-sqlite3 native addon.
+RUN apk add --no-cache build-base python3
 COPY package*.json ./
 RUN npm ci
 COPY tsconfig*.json ./
+COPY scripts ./scripts
 COPY src ./src
 RUN npm run build
 
 FROM node:25-alpine AS runtime
-RUN addgroup -S dicode && adduser -S dicode -G dicode
+# build tools needed once to compile better-sqlite3 during `npm ci --omit=dev`;
+# pruned from the final image layer at the end.
+RUN apk add --no-cache --virtual .build-deps build-base python3 \
+    && addgroup -S dicode && adduser -S dicode -G dicode
 WORKDIR /app
 COPY package*.json ./
-RUN npm ci --omit=dev
+RUN npm ci --omit=dev && apk del .build-deps
 COPY --from=build /app/dist ./dist
+
+# Persistence layer: SQLite database lives under /var/lib/dicode. Mount a
+# Docker volume here so the DB survives container restarts. The default
+# DICODE_RELAY_DB path matches this directory.
+#
+#   docker run -v dicode-relay-data:/var/lib/dicode ...
+#
+RUN mkdir -p /var/lib/dicode && chown -R dicode:dicode /var/lib/dicode
+VOLUME ["/var/lib/dicode"]
+ENV DICODE_RELAY_DB=/var/lib/dicode/relay.db
+
 USER dicode
 EXPOSE 5553
 CMD ["node", "dist/index.js"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "dicode-relay",
       "version": "0.1.0",
       "dependencies": {
+        "better-sqlite3": "^12.8.0",
         "express": "^5.0.1",
         "grant": "^5.4.22",
         "uuid": "^11.0.3",
@@ -16,6 +17,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
+        "@types/better-sqlite3": "^7.6.13",
         "@types/express": "^5.0.0",
         "@types/node": "^22.10.0",
         "@types/uuid": "^10.0.0",
@@ -1170,6 +1172,16 @@
         "win32"
       ]
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -1846,6 +1858,60 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.8.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.8.0.tgz",
+      "integrity": "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "node_modules/bn.js": {
       "version": "4.12.3",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
@@ -1894,6 +1960,30 @@
       "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
     },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
@@ -2004,6 +2094,12 @@
         "node": ">= 16"
       }
     },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2103,6 +2199,21 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -2111,6 +2222,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -2127,6 +2247,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dunder-proto": {
@@ -2196,6 +2325,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/es-define-property": {
@@ -2469,6 +2607,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -2574,6 +2721,12 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -2668,6 +2821,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2741,6 +2900,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "10.5.0",
@@ -2948,6 +3113,26 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2989,6 +3174,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/ipaddr.js": {
@@ -3349,6 +3540,18 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -3376,6 +3579,15 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
@@ -3385,6 +3597,12 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -3411,6 +3629,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -3425,6 +3649,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/oauth-sign": {
@@ -3661,6 +3897,33 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3698,6 +3961,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -3747,6 +4020,44 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/request-compose": {
@@ -3880,8 +4191,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -3893,7 +4203,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4068,6 +4377,51 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4100,6 +4454,15 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -4229,6 +4592,34 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/test-exclude": {
@@ -4388,6 +4779,18 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4478,6 +4881,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "11.1.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc --project tsconfig.build.json && node scripts/copy-assets.mjs",
     "start": "node dist/index.js",
     "dev": "STATUS_PASSWORD=admin tsx watch src/index.ts",
     "test": "vitest run",
@@ -21,6 +21,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "better-sqlite3": "^12.8.0",
     "express": "^5.0.1",
     "grant": "^5.4.22",
     "uuid": "^11.0.3",
@@ -29,6 +30,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
+    "@types/better-sqlite3": "^7.6.13",
     "@types/express": "^5.0.0",
     "@types/node": "^22.10.0",
     "@types/uuid": "^10.0.0",

--- a/scripts/copy-assets.mjs
+++ b/scripts/copy-assets.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+// Copy non-TS assets (currently: SQL migration files) into `dist/` so the
+// compiled code can find them via `fileURLToPath(import.meta.url)`.
+
+import { cpSync, existsSync, mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = resolve(here, "..");
+const src = resolve(root, "src/db/migrations");
+const dst = resolve(root, "dist/src/db/migrations");
+
+if (!existsSync(src)) {
+  console.error(`copy-assets: source ${src} does not exist`);
+  process.exit(1);
+}
+
+mkdirSync(dirname(dst), { recursive: true });
+cpSync(src, dst, { recursive: true });
+console.log(`copy-assets: copied ${src} -> ${dst}`);

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,0 +1,430 @@
+/**
+ * SQLite persistence layer for dicode-relay.
+ *
+ * Exposes a small typed API (`Db`) backed by `better-sqlite3`. Callers never
+ * see raw SQL or the underlying `Database` handle — this keeps the persistence
+ * boundary narrow and easy to port to Postgres later.
+ *
+ * The database file path is resolved from `DICODE_RELAY_DB` with a dev-friendly
+ * fallback of `./data/relay.db`. The production Dockerfile mounts
+ * `/var/lib/dicode/relay.db`.
+ */
+
+import Database from "better-sqlite3";
+import type { Database as BetterSqliteDatabase, Statement } from "better-sqlite3";
+import { mkdirSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type Tier = "free" | "pro" | "team";
+
+export interface GithubProfile {
+  githubId: number;
+  login: string;
+  email?: string | null;
+}
+
+export interface User {
+  id: number;
+  githubId: number;
+  githubLogin: string;
+  email: string | null;
+  githubAccessTokenEncrypted: Buffer | null;
+  createdAt: number;
+}
+
+export interface DaemonRow {
+  uuid: string;
+  userId: number;
+  label: string | null;
+  firstSeen: number;
+  lastSeen: number;
+}
+
+export interface Plan {
+  userId: number;
+  tier: Tier;
+  hookQuotaMonthly: number;
+  concurrentDaemons: number;
+  oauthProviders: string[] | "*";
+  stripeSubId: string | null;
+  renewsAt: number | null;
+}
+
+export interface Db {
+  // users
+  upsertUserFromGithub(gh: GithubProfile, token?: Buffer): User;
+  getUserById(id: number): User | null;
+
+  // daemons
+  getDaemon(uuid: string): DaemonRow | null;
+  claimDaemon(uuid: string, userId: number, label?: string): void;
+  countActiveDaemonsForUser(userId: number, uuids: Iterable<string>): number;
+
+  // plans
+  getPlan(userId: number): Plan;
+  setPlan(userId: number, tier: Tier): void;
+
+  // usage
+  incrementHookUsage(userId: number, period: string): number;
+
+  // lifecycle
+  close(): void;
+}
+
+// ---------------------------------------------------------------------------
+// Plan tier defaults
+// ---------------------------------------------------------------------------
+
+interface PlanDefaults {
+  hookQuotaMonthly: number;
+  concurrentDaemons: number;
+  oauthProviders: string[] | "*";
+}
+
+const PLAN_DEFAULTS: Record<Tier, PlanDefaults> = {
+  free: { hookQuotaMonthly: 1_000, concurrentDaemons: 1, oauthProviders: ["github"] },
+  pro: { hookQuotaMonthly: 50_000, concurrentDaemons: 3, oauthProviders: "*" },
+  team: { hookQuotaMonthly: 500_000, concurrentDaemons: 10, oauthProviders: "*" },
+};
+
+// ---------------------------------------------------------------------------
+// Row shapes as returned by better-sqlite3 (internal — never leak out)
+// ---------------------------------------------------------------------------
+
+interface UserRow {
+  id: number;
+  github_id: number;
+  github_login: string;
+  email: string | null;
+  github_access_token_encrypted: Buffer | null;
+  created_at: number;
+}
+
+interface DaemonSqlRow {
+  uuid: string;
+  user_id: number;
+  label: string | null;
+  first_seen: number;
+  last_seen: number;
+}
+
+interface PlanRow {
+  user_id: number;
+  tier: Tier;
+  hook_quota_monthly: number;
+  concurrent_daemons: number;
+  oauth_providers: string;
+  stripe_sub_id: string | null;
+  renews_at: number | null;
+}
+
+interface HookUsageRow {
+  count: number;
+}
+
+interface SchemaVersionRow {
+  version: number;
+}
+
+interface DaemonUuidOnlyRow {
+  uuid: string;
+}
+
+interface PragmaForeignKeysRow {
+  foreign_keys: number;
+}
+
+// ---------------------------------------------------------------------------
+// Migrations
+// ---------------------------------------------------------------------------
+
+const MIGRATION_FILE_RE = /^(\d{3})_[a-z0-9_]+\.sql$/;
+
+function migrationsDir(): string {
+  const thisFile = fileURLToPath(import.meta.url);
+  return join(dirname(thisFile), "migrations");
+}
+
+function runMigrations(db: BetterSqliteDatabase): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS schema_version (
+      version INTEGER PRIMARY KEY
+    );
+  `);
+
+  const applied = new Set(
+    (db.prepare("SELECT version FROM schema_version").all() as SchemaVersionRow[]).map(
+      (r) => r.version,
+    ),
+  );
+
+  const dir = migrationsDir();
+  const files = readdirSync(dir)
+    .filter((f) => MIGRATION_FILE_RE.test(f))
+    .sort();
+
+  for (const file of files) {
+    const match = MIGRATION_FILE_RE.exec(file);
+    if (!match) continue;
+    const versionStr = match[1];
+    if (versionStr === undefined) continue;
+    const version = Number.parseInt(versionStr, 10);
+    if (applied.has(version)) continue;
+
+    const sql = readFileSync(join(dir, file), "utf8");
+    const tx = db.transaction(() => {
+      db.exec(sql);
+      db.prepare("INSERT INTO schema_version (version) VALUES (?)").run(version);
+    });
+    tx();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Path resolution
+// ---------------------------------------------------------------------------
+
+function resolveDbPath(explicit?: string): string {
+  if (explicit !== undefined && explicit !== "") return explicit;
+  const fromEnv = process.env.DICODE_RELAY_DB;
+  if (fromEnv !== undefined && fromEnv !== "") return fromEnv;
+  return join(process.cwd(), "data", "relay.db");
+}
+
+// ---------------------------------------------------------------------------
+// Row mappers
+// ---------------------------------------------------------------------------
+
+function mapUser(row: UserRow): User {
+  return {
+    id: row.id,
+    githubId: row.github_id,
+    githubLogin: row.github_login,
+    email: row.email,
+    githubAccessTokenEncrypted: row.github_access_token_encrypted,
+    createdAt: row.created_at,
+  };
+}
+
+function mapDaemon(row: DaemonSqlRow): DaemonRow {
+  return {
+    uuid: row.uuid,
+    userId: row.user_id,
+    label: row.label,
+    firstSeen: row.first_seen,
+    lastSeen: row.last_seen,
+  };
+}
+
+function parseOauthProviders(raw: string): string[] | "*" {
+  if (raw === "*") return "*";
+  const parsed: unknown = JSON.parse(raw);
+  if (!Array.isArray(parsed) || !parsed.every((v): v is string => typeof v === "string")) {
+    throw new Error(`plans.oauth_providers is malformed: ${raw}`);
+  }
+  return parsed;
+}
+
+function serializeOauthProviders(value: string[] | "*"): string {
+  return value === "*" ? "*" : JSON.stringify(value);
+}
+
+function mapPlan(row: PlanRow): Plan {
+  return {
+    userId: row.user_id,
+    tier: row.tier,
+    hookQuotaMonthly: row.hook_quota_monthly,
+    concurrentDaemons: row.concurrent_daemons,
+    oauthProviders: parseOauthProviders(row.oauth_providers),
+    stripeSubId: row.stripe_sub_id,
+    renewsAt: row.renews_at,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Db implementation
+// ---------------------------------------------------------------------------
+
+interface Statements {
+  upsertUser: Statement<[number, string, string | null, Buffer | null, number]>;
+  getUserByGithubId: Statement<[number]>;
+  getUserById: Statement<[number]>;
+  getDaemon: Statement<[string]>;
+  claimDaemon: Statement<[string, number, string | null, number, number]>;
+  listDaemonUuidsForUser: Statement<[number]>;
+  getPlan: Statement<[number]>;
+  upsertPlan: Statement<[number, Tier, number, number, string, string | null, number | null]>;
+  getHookUsage: Statement<[number, string]>;
+  incrementHookUsage: Statement<[number, string]>;
+}
+
+class SqliteDb implements Db {
+  private readonly handle: BetterSqliteDatabase;
+  private readonly stmts: Statements;
+
+  constructor(handle: BetterSqliteDatabase) {
+    this.handle = handle;
+    this.stmts = {
+      upsertUser: handle.prepare(
+        `INSERT INTO users (github_id, github_login, email, github_access_token_encrypted, created_at)
+         VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT(github_id) DO UPDATE SET
+           github_login = excluded.github_login,
+           email = excluded.email,
+           github_access_token_encrypted =
+             COALESCE(excluded.github_access_token_encrypted, users.github_access_token_encrypted)`,
+      ),
+      getUserByGithubId: handle.prepare("SELECT * FROM users WHERE github_id = ?"),
+      getUserById: handle.prepare("SELECT * FROM users WHERE id = ?"),
+      getDaemon: handle.prepare("SELECT * FROM daemons WHERE uuid = ?"),
+      claimDaemon: handle.prepare(
+        `INSERT INTO daemons (uuid, user_id, label, first_seen, last_seen)
+         VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT(uuid) DO UPDATE SET
+           user_id = excluded.user_id,
+           label = COALESCE(excluded.label, daemons.label),
+           last_seen = excluded.last_seen`,
+      ),
+      listDaemonUuidsForUser: handle.prepare("SELECT uuid FROM daemons WHERE user_id = ?"),
+      getPlan: handle.prepare("SELECT * FROM plans WHERE user_id = ?"),
+      upsertPlan: handle.prepare(
+        `INSERT INTO plans (user_id, tier, hook_quota_monthly, concurrent_daemons, oauth_providers, stripe_sub_id, renews_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(user_id) DO UPDATE SET
+           tier = excluded.tier,
+           hook_quota_monthly = excluded.hook_quota_monthly,
+           concurrent_daemons = excluded.concurrent_daemons,
+           oauth_providers = excluded.oauth_providers`,
+      ),
+      getHookUsage: handle.prepare("SELECT count FROM hook_usage WHERE user_id = ? AND period = ?"),
+      incrementHookUsage: handle.prepare(
+        `INSERT INTO hook_usage (user_id, period, count)
+         VALUES (?, ?, 1)
+         ON CONFLICT(user_id, period) DO UPDATE SET count = hook_usage.count + 1`,
+      ),
+    };
+  }
+
+  upsertUserFromGithub(gh: GithubProfile, token?: Buffer): User {
+    const now = Math.floor(Date.now() / 1000);
+    const email = gh.email ?? null;
+    const tokenBuf = token ?? null;
+    const tx = this.handle.transaction(() => {
+      this.stmts.upsertUser.run(gh.githubId, gh.login, email, tokenBuf, now);
+      const row = this.stmts.getUserByGithubId.get(gh.githubId) as UserRow | undefined;
+      if (row === undefined) {
+        throw new Error("upsertUserFromGithub: row disappeared after insert");
+      }
+      return row;
+    });
+    return mapUser(tx());
+  }
+
+  getUserById(id: number): User | null {
+    const row = this.stmts.getUserById.get(id) as UserRow | undefined;
+    return row === undefined ? null : mapUser(row);
+  }
+
+  getDaemon(uuid: string): DaemonRow | null {
+    const row = this.stmts.getDaemon.get(uuid) as DaemonSqlRow | undefined;
+    return row === undefined ? null : mapDaemon(row);
+  }
+
+  claimDaemon(uuid: string, userId: number, label?: string): void {
+    const now = Math.floor(Date.now() / 1000);
+    this.stmts.claimDaemon.run(uuid, userId, label ?? null, now, now);
+  }
+
+  countActiveDaemonsForUser(userId: number, uuids: Iterable<string>): number {
+    const active = new Set(uuids);
+    if (active.size === 0) return 0;
+    const owned = this.stmts.listDaemonUuidsForUser.all(userId) as DaemonUuidOnlyRow[];
+    let n = 0;
+    for (const row of owned) {
+      if (active.has(row.uuid)) n++;
+    }
+    return n;
+  }
+
+  getPlan(userId: number): Plan {
+    const row = this.stmts.getPlan.get(userId) as PlanRow | undefined;
+    if (row !== undefined) return mapPlan(row);
+    const defaults = PLAN_DEFAULTS.free;
+    return {
+      userId,
+      tier: "free",
+      hookQuotaMonthly: defaults.hookQuotaMonthly,
+      concurrentDaemons: defaults.concurrentDaemons,
+      oauthProviders: defaults.oauthProviders,
+      stripeSubId: null,
+      renewsAt: null,
+    };
+  }
+
+  setPlan(userId: number, tier: Tier): void {
+    const d = PLAN_DEFAULTS[tier];
+    this.stmts.upsertPlan.run(
+      userId,
+      tier,
+      d.hookQuotaMonthly,
+      d.concurrentDaemons,
+      serializeOauthProviders(d.oauthProviders),
+      null,
+      null,
+    );
+  }
+
+  incrementHookUsage(userId: number, period: string): number {
+    const tx = this.handle.transaction(() => {
+      this.stmts.incrementHookUsage.run(userId, period);
+      const row = this.stmts.getHookUsage.get(userId, period) as HookUsageRow | undefined;
+      if (row === undefined) {
+        throw new Error("incrementHookUsage: row disappeared after upsert");
+      }
+      return row.count;
+    });
+    return tx();
+  }
+
+  close(): void {
+    this.handle.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export interface OpenDbOptions {
+  /** Explicit path. Overrides `DICODE_RELAY_DB` and the default. */
+  path?: string;
+}
+
+/**
+ * Open (or create) the relay database. Creates the parent directory if it
+ * does not exist, enables WAL and foreign keys, then runs pending migrations.
+ */
+export function openDb(options: OpenDbOptions = {}): Db {
+  const path = resolveDbPath(options.path);
+  mkdirSync(dirname(path), { recursive: true });
+
+  const handle = new Database(path);
+  handle.pragma("journal_mode = WAL");
+  handle.pragma("foreign_keys = ON");
+
+  // Sanity-check that foreign keys really are on (the pragma is silently
+  // ignored inside a transaction, so we verify once at open time).
+  const fk = handle.pragma("foreign_keys") as PragmaForeignKeysRow[];
+  if (fk[0]?.foreign_keys !== 1) {
+    throw new Error("failed to enable SQLite foreign_keys pragma");
+  }
+
+  runMigrations(handle);
+
+  return new SqliteDb(handle);
+}

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -12,7 +12,7 @@
 
 import Database from "better-sqlite3";
 import type { Database as BetterSqliteDatabase, Statement } from "better-sqlite3";
-import { mkdirSync, readdirSync, readFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -55,6 +55,22 @@ export interface Plan {
   renewsAt: number | null;
 }
 
+/**
+ * Raised by `claimDaemonStrict` when a daemon UUID is already owned by a
+ * different user. The strict variant refuses to silently rebind — callers
+ * (notably #14's claim flow) should surface this as 409 Conflict.
+ */
+export class DaemonAlreadyClaimedError extends Error {
+  readonly uuid: string;
+  readonly ownerUserId: number;
+  constructor(uuid: string, ownerUserId: number) {
+    super(`daemon ${uuid} is already claimed by user ${String(ownerUserId)}`);
+    this.name = "DaemonAlreadyClaimedError";
+    this.uuid = uuid;
+    this.ownerUserId = ownerUserId;
+  }
+}
+
 export interface Db {
   // users
   upsertUserFromGithub(gh: GithubProfile, token?: Buffer): User;
@@ -62,7 +78,18 @@ export interface Db {
 
   // daemons
   getDaemon(uuid: string): DaemonRow | null;
+  /**
+   * Upsert variant — silently rebinds a UUID to a different user. Kept for
+   * backwards compatibility and tests; new callers should prefer
+   * `claimDaemonStrict` unless they explicitly want rebinding semantics.
+   */
   claimDaemon(uuid: string, userId: number, label?: string): void;
+  /**
+   * Strict variant: insert a new row, refresh `last_seen` (and optionally the
+   * label) when the same user re-claims, or throw `DaemonAlreadyClaimedError`
+   * when a different user tries to claim the same UUID.
+   */
+  claimDaemonStrict(uuid: string, userId: number, label?: string): void;
   countActiveDaemonsForUser(userId: number, uuids: Iterable<string>): number;
 
   // plans
@@ -259,7 +286,6 @@ interface Statements {
   listDaemonUuidsForUser: Statement<[number]>;
   getPlan: Statement<[number]>;
   upsertPlan: Statement<[number, Tier, number, number, string, string | null, number | null]>;
-  getHookUsage: Statement<[number, string]>;
   incrementHookUsage: Statement<[number, string]>;
 }
 
@@ -271,11 +297,14 @@ class SqliteDb implements Db {
     this.handle = handle;
     this.stmts = {
       upsertUser: handle.prepare(
+        // NOTE: `email` uses COALESCE so callers that refresh a user on an
+        // OAuth roundtrip without an email scope do not clobber a previously
+        // stored address. Same pattern as the encrypted-token column.
         `INSERT INTO users (github_id, github_login, email, github_access_token_encrypted, created_at)
          VALUES (?, ?, ?, ?, ?)
          ON CONFLICT(github_id) DO UPDATE SET
            github_login = excluded.github_login,
-           email = excluded.email,
+           email = COALESCE(excluded.email, users.email),
            github_access_token_encrypted =
              COALESCE(excluded.github_access_token_encrypted, users.github_access_token_encrypted)`,
       ),
@@ -301,11 +330,14 @@ class SqliteDb implements Db {
            concurrent_daemons = excluded.concurrent_daemons,
            oauth_providers = excluded.oauth_providers`,
       ),
-      getHookUsage: handle.prepare("SELECT count FROM hook_usage WHERE user_id = ? AND period = ?"),
       incrementHookUsage: handle.prepare(
+        // Single atomic upsert-and-read via RETURNING. better-sqlite3 is
+        // synchronous per process and the whole row is produced inside one
+        // SQL statement, so no wrapping transaction is needed.
         `INSERT INTO hook_usage (user_id, period, count)
          VALUES (?, ?, 1)
-         ON CONFLICT(user_id, period) DO UPDATE SET count = hook_usage.count + 1`,
+         ON CONFLICT(user_id, period) DO UPDATE SET count = hook_usage.count + 1
+         RETURNING count`,
       ),
     };
   }
@@ -340,6 +372,23 @@ class SqliteDb implements Db {
     this.stmts.claimDaemon.run(uuid, userId, label ?? null, now, now);
   }
 
+  claimDaemonStrict(uuid: string, userId: number, label?: string): void {
+    const now = Math.floor(Date.now() / 1000);
+    const tx = this.handle.transaction(() => {
+      const existing = this.stmts.getDaemon.get(uuid) as DaemonSqlRow | undefined;
+      if (existing === undefined) {
+        this.stmts.claimDaemon.run(uuid, userId, label ?? null, now, now);
+        return;
+      }
+      if (existing.user_id !== userId) {
+        throw new DaemonAlreadyClaimedError(uuid, existing.user_id);
+      }
+      // Same owner — refresh last_seen and optionally the label.
+      this.stmts.claimDaemon.run(uuid, userId, label ?? existing.label, now, now);
+    });
+    tx();
+  }
+
   countActiveDaemonsForUser(userId: number, uuids: Iterable<string>): number {
     const active = new Set(uuids);
     if (active.size === 0) return 0;
@@ -366,6 +415,10 @@ class SqliteDb implements Db {
     };
   }
 
+  // TODO(#18, #20): setPlan currently wipes stripe_sub_id / renews_at on
+  // every tier change. When billing integration lands, split this into a
+  // tier-only update and a separate billing-aware setter so re-tiering a Pro
+  // user to Team does not drop their Stripe subscription reference.
   setPlan(userId: number, tier: Tier): void {
     const d = PLAN_DEFAULTS[tier];
     this.stmts.upsertPlan.run(
@@ -380,15 +433,11 @@ class SqliteDb implements Db {
   }
 
   incrementHookUsage(userId: number, period: string): number {
-    const tx = this.handle.transaction(() => {
-      this.stmts.incrementHookUsage.run(userId, period);
-      const row = this.stmts.getHookUsage.get(userId, period) as HookUsageRow | undefined;
-      if (row === undefined) {
-        throw new Error("incrementHookUsage: row disappeared after upsert");
-      }
-      return row.count;
-    });
-    return tx();
+    const row = this.stmts.incrementHookUsage.get(userId, period) as HookUsageRow | undefined;
+    if (row === undefined) {
+      throw new Error("incrementHookUsage: RETURNING produced no row");
+    }
+    return row.count;
   }
 
   close(): void {
@@ -413,6 +462,8 @@ export function openDb(options: OpenDbOptions = {}): Db {
   const path = resolveDbPath(options.path);
   mkdirSync(dirname(path), { recursive: true });
 
+  const existedBefore = existsSync(path);
+
   const handle = new Database(path);
   handle.pragma("journal_mode = WAL");
   handle.pragma("foreign_keys = ON");
@@ -422,6 +473,23 @@ export function openDb(options: OpenDbOptions = {}): Db {
   const fk = handle.pragma("foreign_keys") as PragmaForeignKeysRow[];
   if (fk[0]?.foreign_keys !== 1) {
     throw new Error("failed to enable SQLite foreign_keys pragma");
+  }
+
+  // Narrow file permissions to 0600 so other local users cannot read the DB.
+  // The users table will eventually hold encrypted GitHub tokens (#13); even
+  // in their absence, email addresses are PII. Only narrow when the caller is
+  // inheriting defaults: if the file already existed before this call and has
+  // stricter perms set by an operator we don't widen — we only chmod when the
+  // mode has group/other bits.
+  try {
+    const st = statSync(path);
+    const looseBits = st.mode & 0o077;
+    if (!existedBefore || looseBits !== 0) {
+      chmodSync(path, 0o600);
+    }
+  } catch {
+    // stat/chmod can fail on some platforms (e.g. Windows). Not fatal — the
+    // Dockerfile runs as a dedicated user with an exclusive volume anyway.
   }
 
   runMigrations(handle);

--- a/src/db/migrations/001_init.sql
+++ b/src/db/migrations/001_init.sql
@@ -1,0 +1,37 @@
+-- 001_init.sql — initial schema for dicode-relay persistence layer.
+-- See issue #12 in dicode-ayo/dicode-relay.
+
+CREATE TABLE users (
+  id                            INTEGER PRIMARY KEY AUTOINCREMENT,
+  github_id                     INTEGER UNIQUE NOT NULL,
+  github_login                  TEXT NOT NULL,
+  email                         TEXT,
+  github_access_token_encrypted BLOB,
+  created_at                    INTEGER NOT NULL
+);
+
+CREATE TABLE daemons (
+  uuid        TEXT PRIMARY KEY,
+  user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  label       TEXT,
+  first_seen  INTEGER NOT NULL,
+  last_seen   INTEGER NOT NULL
+);
+CREATE INDEX daemons_user_id ON daemons(user_id);
+
+CREATE TABLE plans (
+  user_id            INTEGER PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+  tier               TEXT NOT NULL CHECK (tier IN ('free','pro','team')),
+  hook_quota_monthly INTEGER NOT NULL,
+  concurrent_daemons INTEGER NOT NULL,
+  oauth_providers    TEXT NOT NULL,
+  stripe_sub_id      TEXT,
+  renews_at          INTEGER
+);
+
+CREATE TABLE hook_usage (
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  period  TEXT NOT NULL,
+  count   INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (user_id, period)
+);

--- a/tests/db/db.test.ts
+++ b/tests/db/db.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { mkdtempSync, rmSync, existsSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdtempSync, rmSync, existsSync, statSync } from "node:fs";
+import { tmpdir, platform } from "node:os";
 import { join } from "node:path";
 import Database from "better-sqlite3";
 
-import { openDb, type Db } from "../../src/db/index.js";
+import { openDb, type Db, DaemonAlreadyClaimedError } from "../../src/db/index.js";
 
 interface Ctx {
   dir: string;
@@ -275,6 +275,120 @@ describe("hook usage", () => {
     expect(sorted[0]).toBe(1);
     expect(sorted[sorted.length - 1]).toBe(N);
     expect(new Set(sorted).size).toBe(N);
+  });
+});
+
+describe("db file permissions", () => {
+  it("sets mode 0600 on a freshly created database file", () => {
+    if (platform() === "win32") return; // POSIX perms don't apply
+    const st = statSync(ctx.dbPath);
+    const looseBits = st.mode & 0o077;
+    expect(looseBits).toBe(0);
+  });
+
+  it("narrows mode to 0600 when opening a loose-permissioned existing file", async () => {
+    if (platform() === "win32") return;
+    // Close, widen, reopen.
+    ctx.db.close();
+    const { chmodSync } = await import("node:fs");
+    chmodSync(ctx.dbPath, 0o644);
+    ctx.db = openDb({ path: ctx.dbPath });
+    const st = statSync(ctx.dbPath);
+    expect(st.mode & 0o077).toBe(0);
+  });
+});
+
+describe("upsertUserFromGithub email preservation", () => {
+  it("preserves existing email when a subsequent call omits it", () => {
+    const a = ctx.db.upsertUserFromGithub({
+      githubId: 100,
+      login: "alice",
+      email: "alice@example.com",
+    });
+    // Second call without email should NOT wipe the stored one.
+    const b = ctx.db.upsertUserFromGithub({ githubId: 100, login: "alice-renamed" });
+    expect(b.id).toBe(a.id);
+    expect(b.githubLogin).toBe("alice-renamed");
+    expect(b.email).toBe("alice@example.com");
+  });
+
+  it("overwrites email when a new non-null value is supplied", () => {
+    ctx.db.upsertUserFromGithub({
+      githubId: 101,
+      login: "alice",
+      email: "old@example.com",
+    });
+    const b = ctx.db.upsertUserFromGithub({
+      githubId: 101,
+      login: "alice",
+      email: "new@example.com",
+    });
+    expect(b.email).toBe("new@example.com");
+  });
+});
+
+describe("claimDaemonStrict", () => {
+  const uuid = "d".repeat(64);
+
+  it("inserts a new row when the uuid is unknown", () => {
+    const u = ctx.db.upsertUserFromGithub({ githubId: 200, login: "alice" });
+    ctx.db.claimDaemonStrict(uuid, u.id, "laptop");
+    const d = ctx.db.getDaemon(uuid);
+    expect(d?.userId).toBe(u.id);
+    expect(d?.label).toBe("laptop");
+  });
+
+  it("refreshes last_seen on re-claim by the same owner", () => {
+    const u = ctx.db.upsertUserFromGithub({ githubId: 201, login: "alice" });
+    ctx.db.claimDaemonStrict(uuid, u.id, "laptop");
+    const before = ctx.db.getDaemon(uuid)?.lastSeen ?? 0;
+    ctx.db.claimDaemonStrict(uuid, u.id);
+    const after = ctx.db.getDaemon(uuid)?.lastSeen ?? 0;
+    expect(after).toBeGreaterThanOrEqual(before);
+  });
+
+  it("preserves the original label when re-claim omits one", () => {
+    const u = ctx.db.upsertUserFromGithub({ githubId: 202, login: "alice" });
+    ctx.db.claimDaemonStrict(uuid, u.id, "laptop");
+    ctx.db.claimDaemonStrict(uuid, u.id);
+    expect(ctx.db.getDaemon(uuid)?.label).toBe("laptop");
+  });
+
+  it("updates the label when re-claim supplies a new one", () => {
+    const u = ctx.db.upsertUserFromGithub({ githubId: 203, login: "alice" });
+    ctx.db.claimDaemonStrict(uuid, u.id, "laptop");
+    ctx.db.claimDaemonStrict(uuid, u.id, "desktop");
+    expect(ctx.db.getDaemon(uuid)?.label).toBe("desktop");
+  });
+
+  it("throws DaemonAlreadyClaimedError when a different user tries to claim", () => {
+    const a = ctx.db.upsertUserFromGithub({ githubId: 204, login: "alice" });
+    const b = ctx.db.upsertUserFromGithub({ githubId: 205, login: "bob" });
+    ctx.db.claimDaemonStrict(uuid, a.id, "alice-laptop");
+
+    expect(() => {
+      ctx.db.claimDaemonStrict(uuid, b.id, "bob-laptop");
+    }).toThrowError(DaemonAlreadyClaimedError);
+
+    // Original binding and label must be untouched.
+    const d = ctx.db.getDaemon(uuid);
+    expect(d?.userId).toBe(a.id);
+    expect(d?.label).toBe("alice-laptop");
+  });
+
+  it("DaemonAlreadyClaimedError carries the conflicting uuid and owner", () => {
+    const a = ctx.db.upsertUserFromGithub({ githubId: 206, login: "alice" });
+    const b = ctx.db.upsertUserFromGithub({ githubId: 207, login: "bob" });
+    ctx.db.claimDaemonStrict(uuid, a.id);
+    try {
+      ctx.db.claimDaemonStrict(uuid, b.id);
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(DaemonAlreadyClaimedError);
+      const e = err as DaemonAlreadyClaimedError;
+      expect(e.uuid).toBe(uuid);
+      expect(e.ownerUserId).toBe(a.id);
+    }
   });
 });
 

--- a/tests/db/db.test.ts
+++ b/tests/db/db.test.ts
@@ -1,0 +1,304 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Database from "better-sqlite3";
+
+import { openDb, type Db } from "../../src/db/index.js";
+
+interface Ctx {
+  dir: string;
+  dbPath: string;
+  db: Db;
+}
+
+const ctx: Ctx = {
+  dir: "",
+  dbPath: "",
+  db: null as unknown as Db,
+};
+
+beforeEach(() => {
+  ctx.dir = mkdtempSync(join(tmpdir(), "relay-db-"));
+  ctx.dbPath = join(ctx.dir, "relay.db");
+  ctx.db = openDb({ path: ctx.dbPath });
+});
+
+afterEach(() => {
+  ctx.db.close();
+  rmSync(ctx.dir, { recursive: true, force: true });
+});
+
+describe("openDb", () => {
+  it("creates the database file on first open", () => {
+    expect(existsSync(ctx.dbPath)).toBe(true);
+  });
+
+  it("creates the parent directory if it does not exist", () => {
+    ctx.db.close();
+    const nestedDir = join(ctx.dir, "nested", "sub");
+    const nestedPath = join(nestedDir, "relay.db");
+    const db2 = openDb({ path: nestedPath });
+    expect(existsSync(nestedPath)).toBe(true);
+    db2.close();
+  });
+
+  it("has foreign_keys pragma enabled", () => {
+    const raw = new Database(ctx.dbPath);
+    const pragma = raw.pragma("foreign_keys") as { foreign_keys: number }[];
+    expect(pragma[0]?.foreign_keys).toBe(1);
+    raw.close();
+    // The real proof is that openDb would have thrown if fk pragma failed;
+    // also verify via a raw handle that cascade constraints are registered.
+    const raw2 = new Database(ctx.dbPath);
+    raw2.pragma("foreign_keys = ON");
+    raw2
+      .prepare("INSERT INTO users (github_id, github_login, created_at) VALUES (?, ?, ?)")
+      .run(1, "alice", 1000);
+    raw2
+      .prepare("INSERT INTO daemons (uuid, user_id, first_seen, last_seen) VALUES (?, ?, ?, ?)")
+      .run("aa", 1, 1, 1);
+    raw2.prepare("DELETE FROM users WHERE id = ?").run(1);
+    const remaining = raw2.prepare("SELECT COUNT(*) AS n FROM daemons").get() as {
+      n: number;
+    };
+    expect(remaining.n).toBe(0);
+    raw2.close();
+  });
+
+  it("is idempotent — running migrations twice does not error", () => {
+    ctx.db.close();
+    const db2 = openDb({ path: ctx.dbPath });
+    db2.close();
+    const db3 = openDb({ path: ctx.dbPath });
+    db3.close();
+    // Verify schema_version has exactly one row for version 1.
+    const raw = new Database(ctx.dbPath);
+    const rows = raw.prepare("SELECT version FROM schema_version ORDER BY version").all() as {
+      version: number;
+    }[];
+    expect(rows.map((r) => r.version)).toEqual([1]);
+    raw.close();
+    // Re-open for afterEach cleanup.
+    ctx.db = openDb({ path: ctx.dbPath });
+  });
+
+  it("honours DICODE_RELAY_DB when no explicit path is supplied", () => {
+    ctx.db.close();
+    const envPath = join(ctx.dir, "env.db");
+    const saved = process.env.DICODE_RELAY_DB;
+    process.env.DICODE_RELAY_DB = envPath;
+    try {
+      const db2 = openDb();
+      expect(existsSync(envPath)).toBe(true);
+      db2.close();
+    } finally {
+      if (saved === undefined) delete process.env.DICODE_RELAY_DB;
+      else process.env.DICODE_RELAY_DB = saved;
+    }
+    ctx.db = openDb({ path: ctx.dbPath });
+  });
+});
+
+describe("users", () => {
+  it("round-trips upsertUserFromGithub / getUserById", () => {
+    const u = ctx.db.upsertUserFromGithub({
+      githubId: 42,
+      login: "alice",
+      email: "alice@example.com",
+    });
+    expect(u.id).toBeGreaterThan(0);
+    expect(u.githubId).toBe(42);
+    expect(u.githubLogin).toBe("alice");
+    expect(u.email).toBe("alice@example.com");
+    expect(u.githubAccessTokenEncrypted).toBeNull();
+    expect(u.createdAt).toBeGreaterThan(0);
+
+    const fetched = ctx.db.getUserById(u.id);
+    expect(fetched).not.toBeNull();
+    expect(fetched?.githubId).toBe(42);
+  });
+
+  it("upsert updates mutable fields but preserves id", () => {
+    const a = ctx.db.upsertUserFromGithub({ githubId: 7, login: "bob" });
+    const b = ctx.db.upsertUserFromGithub({
+      githubId: 7,
+      login: "bob-renamed",
+      email: "bob@example.com",
+    });
+    expect(b.id).toBe(a.id);
+    expect(b.githubLogin).toBe("bob-renamed");
+    expect(b.email).toBe("bob@example.com");
+  });
+
+  it("upsert preserves existing token when new call omits one", () => {
+    const token = Buffer.from("sekrit");
+    ctx.db.upsertUserFromGithub({ githubId: 9, login: "carol" }, token);
+    const after = ctx.db.upsertUserFromGithub({ githubId: 9, login: "carol" });
+    expect(after.githubAccessTokenEncrypted?.toString()).toBe("sekrit");
+  });
+
+  it("stores and returns a fresh token buffer", () => {
+    const token = Buffer.from([0xde, 0xad, 0xbe, 0xef]);
+    const u = ctx.db.upsertUserFromGithub({ githubId: 11, login: "dave" }, token);
+    expect(u.githubAccessTokenEncrypted?.equals(token)).toBe(true);
+  });
+
+  it("getUserById returns null for unknown id", () => {
+    expect(ctx.db.getUserById(999_999)).toBeNull();
+  });
+
+  it("accepts null email", () => {
+    const u = ctx.db.upsertUserFromGithub({ githubId: 5, login: "eve", email: null });
+    expect(u.email).toBeNull();
+  });
+});
+
+describe("daemons", () => {
+  it("claim + get round-trip", () => {
+    const u = ctx.db.upsertUserFromGithub({ githubId: 1, login: "alice" });
+    ctx.db.claimDaemon("a".repeat(64), u.id, "laptop");
+    const d = ctx.db.getDaemon("a".repeat(64));
+    expect(d).not.toBeNull();
+    expect(d?.userId).toBe(u.id);
+    expect(d?.label).toBe("laptop");
+    expect(d?.firstSeen).toBeGreaterThan(0);
+  });
+
+  it("claim without label stores null", () => {
+    const u = ctx.db.upsertUserFromGithub({ githubId: 2, login: "bob" });
+    ctx.db.claimDaemon("b".repeat(64), u.id);
+    const d = ctx.db.getDaemon("b".repeat(64));
+    expect(d?.label).toBeNull();
+  });
+
+  it("re-claim updates last_seen and preserves label when omitted", () => {
+    const u = ctx.db.upsertUserFromGithub({ githubId: 3, login: "carol" });
+    ctx.db.claimDaemon("c".repeat(64), u.id, "desktop");
+    const first = ctx.db.getDaemon("c".repeat(64));
+    ctx.db.claimDaemon("c".repeat(64), u.id);
+    const second = ctx.db.getDaemon("c".repeat(64));
+    expect(second?.label).toBe("desktop");
+    expect(second?.lastSeen).toBeGreaterThanOrEqual(first?.lastSeen ?? 0);
+  });
+
+  it("getDaemon returns null for unknown uuid", () => {
+    expect(ctx.db.getDaemon("x".repeat(64))).toBeNull();
+  });
+
+  it("countActiveDaemonsForUser filters by the supplied active set", () => {
+    const u = ctx.db.upsertUserFromGithub({ githubId: 4, login: "dave" });
+    ctx.db.claimDaemon("1".repeat(64), u.id);
+    ctx.db.claimDaemon("2".repeat(64), u.id);
+    ctx.db.claimDaemon("3".repeat(64), u.id);
+
+    expect(ctx.db.countActiveDaemonsForUser(u.id, ["1".repeat(64)])).toBe(1);
+    expect(ctx.db.countActiveDaemonsForUser(u.id, ["1".repeat(64), "2".repeat(64)])).toBe(2);
+    // Unknown uuids are ignored
+    expect(ctx.db.countActiveDaemonsForUser(u.id, ["1".repeat(64), "z".repeat(64)])).toBe(1);
+    // Empty active set → 0
+    expect(ctx.db.countActiveDaemonsForUser(u.id, [])).toBe(0);
+    // Other user's uuids don't count even if active
+    const u2 = ctx.db.upsertUserFromGithub({ githubId: 5, login: "eve" });
+    expect(ctx.db.countActiveDaemonsForUser(u2.id, ["1".repeat(64)])).toBe(0);
+  });
+});
+
+describe("plans", () => {
+  it("getPlan returns free defaults for unknown user without inserting a row", () => {
+    const u = ctx.db.upsertUserFromGithub({ githubId: 1, login: "alice" });
+    const p = ctx.db.getPlan(u.id);
+    expect(p.tier).toBe("free");
+    expect(p.hookQuotaMonthly).toBe(1_000);
+    expect(p.concurrentDaemons).toBe(1);
+    expect(p.oauthProviders).toEqual(["github"]);
+    expect(p.stripeSubId).toBeNull();
+    expect(p.renewsAt).toBeNull();
+
+    // Verify no row was inserted on the read.
+    const raw = new Database(ctx.dbPath);
+    const count = raw.prepare("SELECT COUNT(*) AS n FROM plans").get() as { n: number };
+    expect(count.n).toBe(0);
+    raw.close();
+  });
+
+  it("setPlan + getPlan round-trips pro tier", () => {
+    const u = ctx.db.upsertUserFromGithub({ githubId: 2, login: "bob" });
+    ctx.db.setPlan(u.id, "pro");
+    const p = ctx.db.getPlan(u.id);
+    expect(p.tier).toBe("pro");
+    expect(p.hookQuotaMonthly).toBe(50_000);
+    expect(p.concurrentDaemons).toBe(3);
+    expect(p.oauthProviders).toBe("*");
+  });
+
+  it("setPlan + getPlan round-trips team tier", () => {
+    const u = ctx.db.upsertUserFromGithub({ githubId: 3, login: "carol" });
+    ctx.db.setPlan(u.id, "team");
+    const p = ctx.db.getPlan(u.id);
+    expect(p.tier).toBe("team");
+    expect(p.hookQuotaMonthly).toBe(500_000);
+    expect(p.concurrentDaemons).toBe(10);
+    expect(p.oauthProviders).toBe("*");
+  });
+
+  it("setPlan can downgrade back to free", () => {
+    const u = ctx.db.upsertUserFromGithub({ githubId: 4, login: "dave" });
+    ctx.db.setPlan(u.id, "pro");
+    ctx.db.setPlan(u.id, "free");
+    const p = ctx.db.getPlan(u.id);
+    expect(p.tier).toBe("free");
+    expect(p.oauthProviders).toEqual(["github"]);
+  });
+});
+
+describe("hook usage", () => {
+  it("increments atomically and returns the new count", () => {
+    const u = ctx.db.upsertUserFromGithub({ githubId: 1, login: "alice" });
+    expect(ctx.db.incrementHookUsage(u.id, "2026-04")).toBe(1);
+    expect(ctx.db.incrementHookUsage(u.id, "2026-04")).toBe(2);
+    expect(ctx.db.incrementHookUsage(u.id, "2026-04")).toBe(3);
+    // Different period → starts at 1
+    expect(ctx.db.incrementHookUsage(u.id, "2026-05")).toBe(1);
+  });
+
+  it("is atomic under concurrent Promise.all calls", async () => {
+    const u = ctx.db.upsertUserFromGithub({ githubId: 2, login: "bob" });
+    const N = 200;
+    const results = await Promise.all(
+      Array.from({ length: N }, () =>
+        Promise.resolve().then(() => ctx.db.incrementHookUsage(u.id, "2026-04")),
+      ),
+    );
+    // Each call should return a unique count from 1..N
+    const sorted = [...results].sort((a, b) => a - b);
+    expect(sorted[0]).toBe(1);
+    expect(sorted[sorted.length - 1]).toBe(N);
+    expect(new Set(sorted).size).toBe(N);
+  });
+});
+
+describe("foreign-key cascade", () => {
+  it("deleting a user cascades to daemons, plans, and hook_usage", () => {
+    const u = ctx.db.upsertUserFromGithub({ githubId: 1, login: "alice" });
+    ctx.db.claimDaemon("a".repeat(64), u.id, "laptop");
+    ctx.db.setPlan(u.id, "pro");
+    ctx.db.incrementHookUsage(u.id, "2026-04");
+
+    const raw = new Database(ctx.dbPath);
+    raw.pragma("foreign_keys = ON");
+    raw.prepare("DELETE FROM users WHERE id = ?").run(u.id);
+
+    const daemons = raw.prepare("SELECT COUNT(*) AS n FROM daemons").get() as {
+      n: number;
+    };
+    const plans = raw.prepare("SELECT COUNT(*) AS n FROM plans").get() as { n: number };
+    const usage = raw.prepare("SELECT COUNT(*) AS n FROM hook_usage").get() as {
+      n: number;
+    };
+    expect(daemons.n).toBe(0);
+    expect(plans.n).toBe(0);
+    expect(usage.n).toBe(0);
+    raw.close();
+  });
+});


### PR DESCRIPTION
## Summary

Introduces a typed SQLite persistence layer for dicode-relay, backed by `better-sqlite3`. This is the foundation of epic #11 — it unblocks Wave 2 work (#13, #14, #16, #17, #18, #20).

- `src/db/index.ts` — `openDb()` + `Db` interface with cached prepared statements; callers never see raw SQL.
- `src/db/migrations/001_init.sql` — `users`, `daemons`, `plans`, `hook_usage` tables exactly as specified in #12.
- `schema_version` table + idempotent numbered migration runner (`NNN_name.sql`).
- WAL + foreign keys pragmas verified at open time.
- `scripts/copy-assets.mjs` — copies migration SQL into `dist/` during build (tsc does not copy non-TS assets).
- `Dockerfile` — declares `/var/lib/dicode` volume, sets `DICODE_RELAY_DB=/var/lib/dicode/relay.db`, chowns to the `dicode` user, installs native-build toolchain to compile `better-sqlite3`.
- `tests/db/db.test.ts` — 23 tests, real SQLite in `os.tmpdir()`, zero mocks.

## Acceptance criteria (issue #12)

- [x] `npm run test` passes with new `tests/db/*.test.ts` (round-trips every API method, foreign-key cascade, migration idempotency)
- [x] DB file is created on first boot if missing (`openDb` ensures parent dir + creates file)
- [x] `PRAGMA foreign_keys = ON` verified in an init test (and asserted on open)
- [x] Dockerfile documents the volume mount path (`VOLUME ["/var/lib/dicode"]`)
- [x] No raw SQL leaks out of `src/db/` — `Db` is the only export surface

## Design decisions (not explicitly in the issue — call-outs for Wave 2)

- `Plan.oauthProviders` is typed as `string[] | "*"` with `"*"` stored as a sentinel string in SQL. Wave 2 broker-gate (#18) should branch on `=== "*"` for the unrestricted case.
- `getPlan` returns `free` defaults **without inserting a row**, so the `plans` table only contains explicitly set non-free rows. `setPlan` always resets quota/daemon limits/providers to the tier's canonical defaults (no partial edits — ship admin overrides as a later migration).
- `upsertUserFromGithub` preserves the existing encrypted token when the caller omits one, so `#13` can safely update login/email on every OAuth hit without clobbering the stored token.
- `claimDaemon` uses `ON CONFLICT(uuid) DO UPDATE` — re-claiming refreshes `last_seen` and lets a user transfer a UUID between labels; if you want stricter "one owner forever" semantics, add a guard in the caller.
- `countActiveDaemonsForUser` takes the active UUID set from the in-memory relay registry (caller passes it in) — the DB does not know connectivity state.
- Migration runner lives entirely in-process at `openDb` time — no separate CLI step. Add new migrations as `src/db/migrations/NNN_name.sql` and they'll apply on next boot.
- Tier quota/daemon/provider defaults are hard-coded in `PLAN_DEFAULTS` in `src/db/index.ts`. If Wave 2 needs admin-tunable values per user, add columns to `plans` and loosen `setPlan`.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm run test:coverage` — 101/101 tests passing, `src/db/index.ts` at **95.02% lines / 100% functions** (threshold 90/90)
- [x] `npm run build` — produces `dist/src/db/migrations/001_init.sql`

## Local CI evidence

```
> npm run typecheck && npm run lint && npm run format:check && npm run test:coverage && npm run build

> tsc --noEmit          # clean
> eslint src tests      # clean
> prettier --check      # All matched files use Prettier code style!

 Test Files  11 passed (11)
      Tests  101 passed (101)

 % Coverage report from v8
---------------|---------|----------|---------|---------|-----------------------
File           | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
---------------|---------|----------|---------|---------|-----------------------
All files      |   93.56 |     82.1 |     100 |   93.56 |
 db            |   95.02 |    87.93 |     100 |   95.02 |
  index.ts     |   95.02 |    87.93 |     100 |   95.02 | ...22,387-388,424-425
---------------|---------|----------|---------|---------|-----------------------

> tsc --project tsconfig.build.json && node scripts/copy-assets.mjs
copy-assets: copied src/db/migrations -> dist/src/db/migrations
```

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)