### PR TITLE
feat(broker): E2E mock OAuth provider gated by DICODE_E2E_MOCK_PROVIDER

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,11 @@ COPY package*.json ./
 RUN npm ci --omit=dev
 COPY --from=build /app/dist ./dist
 USER dicode
+# Defence-in-depth: explicitly null the E2E mock flag so a rogue base-image
+# layer or orchestrator default can't accidentally flip it on. Production
+# deployments should additionally set NODE_ENV=production, which
+# isE2EMockEnabled() also honors as a hard refusal.
+ENV DICODE_E2E_MOCK_PROVIDER=""
+ENV NODE_ENV="production"
 EXPOSE 5553
 CMD ["node", "dist/index.js"]

--- a/src/broker/e2e-mock.ts
+++ b/src/broker/e2e-mock.ts
@@ -43,9 +43,14 @@ export const MOCK_PROVIDER_KEY = "mock";
  * enabled flag in prod is "attacker writes chosen OAuth tokens into any
  * connected daemon's secret store." The NODE_ENV refusal converts the
  * operator-must-remember invariant into an enforced one.
+ *
+ * The NODE_ENV match is case-insensitive and whitespace-tolerant so that
+ * oddly-capitalised or copy-pasted values like "PRODUCTION" or
+ * " production" still trip the refusal.
  */
 export function isE2EMockEnabled(): boolean {
-  if (process.env.NODE_ENV === "production") return false;
+  const nodeEnv = process.env.NODE_ENV?.trim().toLowerCase();
+  if (nodeEnv === "production") return false;
   return process.env.DICODE_E2E_MOCK_PROVIDER === "1";
 }
 

--- a/src/broker/e2e-mock.ts
+++ b/src/broker/e2e-mock.ts
@@ -1,0 +1,169 @@
+/**
+ * E2E mock OAuth provider — gated behind DICODE_E2E_MOCK_PROVIDER=1.
+ * Must never mount in production.
+ *
+ * Exposes two endpoints, both useful for exercising the broker→daemon token
+ * delivery path end-to-end without any real upstream OAuth provider:
+ *
+ *   GET /connect/mock
+ *     Short-circuits the upstream authorize + code-exchange steps. Reads
+ *     `state` (the session ID created by /auth/mock), looks up the session,
+ *     and redirects the browser to /callback/mock?state=…&access_token=…
+ *     The existing /callback/:provider handler then encrypts and forwards
+ *     the synthetic token to the daemon. This is the flow dicode-relay#31
+ *     specifies, and it lets a test driver exercise the full daemon-issued
+ *     build_auth_url → browser → broker → daemon round-trip.
+ *
+ *   POST /_test/deliver
+ *     A lower-level primitive that bypasses /auth and /connect entirely.
+ *     Takes { uuid, session_id, provider, tokens } directly, builds the
+ *     ECIES envelope using the connected daemon's decrypt pubkey + the
+ *     broker signing key, and forwards. Used for cross-implementation
+ *     wire-shape testing (this is how dicode-core#151 — the broker-sig
+ *     hash-depth mismatch — was uncovered).
+ */
+
+import type { Request, Response, Router } from "express";
+import { Router as makeRouter, json } from "express";
+import { eciesEncrypt } from "./crypto.js";
+import type { OAuthTokenDeliveryPayload } from "../relay/protocol.js";
+import type { RelayServer } from "../relay/server.js";
+import type { SessionStore } from "./sessions.js";
+import { buildDeliverySignaturePayload, type BrokerSigningKey } from "./signing.js";
+
+/** Provider key used throughout the mock flow. */
+export const MOCK_PROVIDER_KEY = "mock";
+
+/** Whether the E2E mock provider is enabled for this process. */
+export function isE2EMockEnabled(): boolean {
+  return process.env.DICODE_E2E_MOCK_PROVIDER === "1";
+}
+
+interface DeliverBody {
+  uuid: string;
+  session_id: string;
+  provider: string;
+  tokens: Record<string, unknown>;
+}
+
+/**
+ * Build the Express router for the E2E mock provider.
+ *
+ * Mount BEFORE the Grant middleware so /connect/mock is handled here and
+ * Grant never sees it, and BEFORE the broker router so /_test/deliver
+ * is reachable.
+ */
+export function buildE2EMockRouter(
+  relay: RelayServer,
+  sessions: SessionStore,
+  brokerKey: BrokerSigningKey,
+  baseUrl: string,
+): Router {
+  const router: Router = makeRouter();
+  router.use(json());
+
+  router.get("/connect/mock", (req: Request, res: Response) => {
+    handleConnectMock(req, res, sessions, baseUrl);
+  });
+
+  router.post("/_test/deliver", (req: Request, res: Response) => {
+    void handleDeliver(req, res, relay, brokerKey);
+  });
+
+  return router;
+}
+
+function handleConnectMock(
+  req: Request,
+  res: Response,
+  sessions: SessionStore,
+  baseUrl: string,
+): void {
+  const rawState = req.query.state;
+  const state = Array.isArray(rawState) ? rawState[0] : rawState;
+  if (typeof state !== "string" || state === "") {
+    res.status(400).send("missing state");
+    return;
+  }
+
+  const session = sessions.get(state);
+  if (session === undefined) {
+    res.status(400).send("session not found");
+    return;
+  }
+  if (session.provider !== MOCK_PROVIDER_KEY) {
+    res.status(400).send("session is not for mock provider");
+    return;
+  }
+
+  const callbackUrl =
+    `${baseUrl}/callback/${MOCK_PROVIDER_KEY}` +
+    `?state=${encodeURIComponent(state)}` +
+    `&access_token=${encodeURIComponent(`mock-token-${state}`)}` +
+    `&token_type=bearer`;
+  res.setHeader("Referrer-Policy", "no-referrer");
+  res.redirect(302, callbackUrl);
+}
+
+async function handleDeliver(
+  req: Request,
+  res: Response,
+  relay: RelayServer,
+  brokerKey: BrokerSigningKey,
+): Promise<void> {
+  const body = req.body as Partial<DeliverBody>;
+  if (!body.uuid || !body.session_id || !body.provider || typeof body.tokens !== "object") {
+    res.status(400).json({ error: "uuid, session_id, provider, tokens required" });
+    return;
+  }
+
+  if (!relay.hasClient(body.uuid)) {
+    res.status(404).json({ error: "daemon uuid not connected to relay" });
+    return;
+  }
+  const client = relay.getClient(body.uuid);
+
+  const deliveryType = "oauth_token_delivery";
+  const plaintext = Buffer.from(JSON.stringify(body.tokens));
+
+  let encrypted: Awaited<ReturnType<typeof eciesEncrypt>>;
+  try {
+    encrypted = await eciesEncrypt(client.decryptPubkey, body.session_id, deliveryType, plaintext);
+  } catch (e) {
+    res.status(500).json({ error: `encrypt failed: ${String(e)}` });
+    return;
+  }
+
+  const payload: OAuthTokenDeliveryPayload = {
+    type: deliveryType,
+    session_id: body.session_id,
+    ephemeral_pubkey: encrypted.ephemeralPubkey,
+    ciphertext: encrypted.ciphertext,
+    nonce: encrypted.nonce,
+  };
+
+  const sigPayload = buildDeliverySignaturePayload(
+    payload.type,
+    payload.session_id,
+    payload.ephemeral_pubkey,
+    payload.ciphertext,
+    payload.nonce,
+  );
+  payload.broker_sig = brokerKey.sign(sigPayload);
+
+  try {
+    const daemonResp = await relay.forward(
+      body.uuid,
+      "POST",
+      "/hooks/oauth-complete",
+      { "Content-Type": ["application/json"] },
+      Buffer.from(JSON.stringify(payload)),
+    );
+    res.status(200).json({
+      daemon_status: daemonResp.status,
+      daemon_body: Buffer.from(daemonResp.body, "base64").toString("utf8"),
+    });
+  } catch (e) {
+    res.status(502).json({ error: `forward failed: ${String(e)}` });
+  }
+}

--- a/src/broker/e2e-mock.ts
+++ b/src/broker/e2e-mock.ts
@@ -34,8 +34,18 @@ import { buildDeliverySignaturePayload, type BrokerSigningKey } from "./signing.
 /** Provider key used throughout the mock flow. */
 export const MOCK_PROVIDER_KEY = "mock";
 
-/** Whether the E2E mock provider is enabled for this process. */
+/**
+ * Whether the E2E mock provider is enabled for this process.
+ *
+ * Fails closed when `NODE_ENV=production` even if the flag is set — the
+ * mock endpoints hand out daemon-decryptable token deliveries to anyone
+ * who can reach the HTTP port, so the consequence of an accidentally
+ * enabled flag in prod is "attacker writes chosen OAuth tokens into any
+ * connected daemon's secret store." The NODE_ENV refusal converts the
+ * operator-must-remember invariant into an enforced one.
+ */
 export function isE2EMockEnabled(): boolean {
+  if (process.env.NODE_ENV === "production") return false;
   return process.env.DICODE_E2E_MOCK_PROVIDER === "1";
 }
 
@@ -57,13 +67,12 @@ export function buildE2EMockRouter(
   relay: RelayServer,
   sessions: SessionStore,
   brokerKey: BrokerSigningKey,
-  baseUrl: string,
 ): Router {
   const router: Router = makeRouter();
   router.use(json());
 
   router.get("/connect/mock", (req: Request, res: Response) => {
-    handleConnectMock(req, res, sessions, baseUrl);
+    handleConnectMock(req, res, sessions);
   });
 
   router.post("/_test/deliver", (req: Request, res: Response) => {
@@ -73,12 +82,7 @@ export function buildE2EMockRouter(
   return router;
 }
 
-function handleConnectMock(
-  req: Request,
-  res: Response,
-  sessions: SessionStore,
-  baseUrl: string,
-): void {
+function handleConnectMock(req: Request, res: Response, sessions: SessionStore): void {
   const rawState = req.query.state;
   const state = Array.isArray(rawState) ? rawState[0] : rawState;
   if (typeof state !== "string" || state === "") {
@@ -95,14 +99,22 @@ function handleConnectMock(
     res.status(400).send("session is not for mock provider");
     return;
   }
+  if (session.expiresAt <= Date.now()) {
+    res.status(400).send("session expired");
+    return;
+  }
 
-  const callbackUrl =
-    `${baseUrl}/callback/${MOCK_PROVIDER_KEY}` +
+  const callbackPath =
+    `/callback/${MOCK_PROVIDER_KEY}` +
     `?state=${encodeURIComponent(state)}` +
     `&access_token=${encodeURIComponent(`mock-token-${state}`)}` +
     `&token_type=bearer`;
   res.setHeader("Referrer-Policy", "no-referrer");
-  res.redirect(302, callbackUrl);
+  res.redirect(302, callbackPath);
+}
+
+function isPlainTokensObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
 }
 
 async function handleDeliver(
@@ -112,7 +124,15 @@ async function handleDeliver(
   brokerKey: BrokerSigningKey,
 ): Promise<void> {
   const body = req.body as Partial<DeliverBody>;
-  if (!body.uuid || !body.session_id || !body.provider || typeof body.tokens !== "object") {
+  if (
+    typeof body.uuid !== "string" ||
+    body.uuid === "" ||
+    typeof body.session_id !== "string" ||
+    body.session_id === "" ||
+    typeof body.provider !== "string" ||
+    body.provider === "" ||
+    !isPlainTokensObject(body.tokens)
+  ) {
     res.status(400).json({ error: "uuid, session_id, provider, tokens required" });
     return;
   }
@@ -130,7 +150,8 @@ async function handleDeliver(
   try {
     encrypted = await eciesEncrypt(client.decryptPubkey, body.session_id, deliveryType, plaintext);
   } catch (e) {
-    res.status(500).json({ error: `encrypt failed: ${String(e)}` });
+    console.error("e2e-mock: encrypt failed", e);
+    res.status(500).json({ error: "encrypt failed" });
     return;
   }
 
@@ -159,11 +180,12 @@ async function handleDeliver(
       { "Content-Type": ["application/json"] },
       Buffer.from(JSON.stringify(payload)),
     );
-    res.status(200).json({
-      daemon_status: daemonResp.status,
-      daemon_body: Buffer.from(daemonResp.body, "base64").toString("utf8"),
-    });
+    // Return only the daemon's HTTP status. The body is intentionally NOT
+    // reflected back — the caller already knows what they sent and the
+    // daemon's reply may contain noisy or sensitive error context.
+    res.status(200).json({ daemon_status: daemonResp.status });
   } catch (e) {
-    res.status(502).json({ error: `forward failed: ${String(e)}` });
+    console.error("e2e-mock: forward failed", e);
+    res.status(502).json({ error: "forward failed" });
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,8 @@ import { loadConfig } from "./config.js";
 import { RelayServer } from "./relay/server.js";
 import { buildGrantMiddleware } from "./broker/grant.js";
 import { buildBrokerRouter } from "./broker/router.js";
-import { buildProviderMap } from "./broker/providers.js";
+import { MOCK_PROVIDER_KEY, buildE2EMockRouter, isE2EMockEnabled } from "./broker/e2e-mock.js";
+import { buildProviderMap, type ProviderConfig } from "./broker/providers.js";
 import { SessionStore } from "./broker/sessions.js";
 import { loadBrokerSigningKey } from "./broker/signing.js";
 import { MetricsCollector } from "./status/metrics.js";
@@ -91,13 +92,39 @@ relayServer.on("client:disconnected", (uuid: string) => {
 // OAuth broker
 // ---------------------------------------------------------------------------
 
-const providers = buildProviderMap(config);
+const realProviders = buildProviderMap(config);
 const sessions = new SessionStore(brokerCfg.session_ttl_ms);
 
-const grantMiddleware = buildGrantMiddleware(providers, serverCfg.base_url);
+// Providers passed to the broker router (session creation in /auth/:provider).
+// If the E2E mock flag is set, include "mock" here so /auth/mock is accepted.
+// Grant must NOT receive the mock entry — /connect/mock is handled by the
+// e2e-mock router, and Grant would otherwise try to dispatch it upstream.
+const brokerProviders = new Map<string, ProviderConfig>(realProviders);
+if (isE2EMockEnabled()) {
+  brokerProviders.set(MOCK_PROVIDER_KEY, {
+    grantKey: MOCK_PROVIDER_KEY,
+    clientId: "mock-client-id",
+    pkce: true,
+    scopes: [],
+  });
+  console.warn(
+    "broker: DICODE_E2E_MOCK_PROVIDER enabled — mock provider registered. DO NOT USE IN PRODUCTION.",
+  );
+  // Mount BEFORE Grant so /connect/mock is intercepted and Grant never sees
+  // it. Also exposes /_test/deliver for low-level wire-shape testing.
+  app.use(buildE2EMockRouter(relayServer, sessions, brokerKey, serverCfg.base_url));
+}
+
+const grantMiddleware = buildGrantMiddleware(realProviders, serverCfg.base_url);
 app.use(grantMiddleware);
 app.use(
-  buildBrokerRouter(relayServer, sessions, providers, relayCfg.timestamp_tolerance_s, brokerKey),
+  buildBrokerRouter(
+    relayServer,
+    sessions,
+    brokerProviders,
+    relayCfg.timestamp_tolerance_s,
+    brokerKey,
+  ),
 );
 
 // ---------------------------------------------------------------------------
@@ -179,7 +206,7 @@ app.get("/health", (_req, res) => {
 httpServer.listen(serverCfg.port, () => {
   console.log(`dicode-relay listening on port ${String(serverCfg.port)}`);
   console.log(`Base URL: ${serverCfg.base_url}`);
-  console.log(`Providers: ${[...providers.keys()].join(", ") || "(none configured)"}`);
+  console.log(`Providers: ${[...brokerProviders.keys()].join(", ") || "(none configured)"}`);
 });
 
 // Graceful shutdown

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,10 @@ const brokerProviders = new Map<string, ProviderConfig>(realProviders);
 if (isE2EMockEnabled()) {
   brokerProviders.set(MOCK_PROVIDER_KEY, {
     grantKey: MOCK_PROVIDER_KEY,
-    clientId: "mock-client-id",
+    // Obviously-fake placeholder — never reaches Grant (see buildGrantMiddleware
+    // call below, which is passed realProviders only). Exists solely to satisfy
+    // the non-empty check in providers.has/buildProviderMap invariants.
+    clientId: "mock-e2e-not-a-real-credential",
     pkce: true,
     scopes: [],
   });
@@ -112,7 +115,7 @@ if (isE2EMockEnabled()) {
   );
   // Mount BEFORE Grant so /connect/mock is intercepted and Grant never sees
   // it. Also exposes /_test/deliver for low-level wire-shape testing.
-  app.use(buildE2EMockRouter(relayServer, sessions, brokerKey, serverCfg.base_url));
+  app.use(buildE2EMockRouter(relayServer, sessions, brokerKey));
 }
 
 const grantMiddleware = buildGrantMiddleware(realProviders, serverCfg.base_url);

--- a/tests/broker/e2e-mock.test.ts
+++ b/tests/broker/e2e-mock.test.ts
@@ -1,0 +1,323 @@
+/**
+ * E2E mock provider tests — real crypto, in-process RelayServer, no mocks.
+ *
+ * Covers:
+ *  - GET /connect/mock — short-circuit redirect to /callback/mock
+ *  - POST /_test/deliver — low-level wire-shape primitive
+ */
+
+import { createHash, createSign, generateKeyPairSync, randomBytes } from "node:crypto";
+import type { Server } from "node:http";
+import express from "express";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { WebSocket } from "ws";
+import { buildE2EMockRouter, MOCK_PROVIDER_KEY } from "../../src/broker/e2e-mock.js";
+import { SessionStore } from "../../src/broker/sessions.js";
+import { verifyDeliverySignature } from "../../src/broker/signing.js";
+import type { BrokerSigningKey } from "../../src/broker/signing.js";
+import { loadBrokerSigningKey } from "../../src/broker/signing.js";
+import { RelayServer } from "../../src/relay/server.js";
+import type { RequestMessage, ResponseMessage } from "../../src/relay/protocol.js";
+import { testRelayOpts, testSessionTtlMs } from "../helpers.js";
+
+const BASE_URL = "https://relay.test.local";
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+function generateSigningIdentity(): {
+  uuid: string;
+  pubkeyBase64: string;
+  decryptPubkeyBase64: string;
+  decryptPubkeyBytes: Buffer;
+  sign: (payload: Buffer) => string;
+} {
+  const { privateKey, publicKey } = generateKeyPairSync("ec", {
+    namedCurve: "prime256v1",
+    publicKeyEncoding: { type: "spki", format: "der" },
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  });
+  const spki = publicKey as Buffer;
+  const pubkeyBytes = Buffer.from(spki.subarray(spki.length - 65));
+  const uuid = createHash("sha256").update(pubkeyBytes).digest("hex");
+
+  const { publicKey: decryptPublicKey } = generateKeyPairSync("ec", {
+    namedCurve: "prime256v1",
+    publicKeyEncoding: { type: "spki", format: "der" },
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  });
+  const decryptSpki = decryptPublicKey as Buffer;
+  const decryptPubkeyBytes = Buffer.from(decryptSpki.subarray(decryptSpki.length - 65));
+
+  const sign = (payload: Buffer): string => {
+    const signer = createSign("SHA256");
+    signer.update(payload);
+    return signer.sign(privateKey, "base64");
+  };
+
+  return {
+    uuid,
+    pubkeyBase64: pubkeyBytes.toString("base64"),
+    decryptPubkeyBase64: decryptPubkeyBytes.toString("base64"),
+    decryptPubkeyBytes,
+    sign,
+  };
+}
+
+function buildHelloPayload(nonce: string, timestamp: number): Buffer {
+  const nonceBytes = Buffer.from(nonce, "hex");
+  const tsBytes = Buffer.allocUnsafe(8);
+  tsBytes.writeBigUInt64BE(BigInt(timestamp));
+  return Buffer.concat([nonceBytes, tsBytes]);
+}
+
+async function connectDaemon(
+  relayPort: number,
+  identity: ReturnType<typeof generateSigningIdentity>,
+): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://localhost:${relayPort.toString()}`);
+    ws.once("message", (data: Buffer | string) => {
+      const challenge = JSON.parse(typeof data === "string" ? data : data.toString()) as {
+        nonce: string;
+      };
+      const timestamp = Math.floor(Date.now() / 1000);
+      const payload = buildHelloPayload(challenge.nonce, timestamp);
+      const sig = identity.sign(payload);
+
+      ws.send(
+        JSON.stringify({
+          type: "hello",
+          uuid: identity.uuid,
+          pubkey: identity.pubkeyBase64,
+          decrypt_pubkey: identity.decryptPubkeyBase64,
+          sig,
+          timestamp,
+        }),
+      );
+
+      ws.once("message", (data2: Buffer | string) => {
+        const welcome = JSON.parse(typeof data2 === "string" ? data2 : data2.toString()) as {
+          type: string;
+        };
+        if (welcome.type === "welcome") {
+          resolve(ws);
+        } else {
+          reject(new Error(`Expected welcome, got ${welcome.type}`));
+        }
+      });
+    });
+    ws.once("error", reject);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+describe("E2E mock router", () => {
+  let relayServer: RelayServer;
+  let httpServer: Server;
+  let httpPort: number;
+  let sessions: SessionStore;
+  let brokerKey: BrokerSigningKey;
+
+  beforeEach(async () => {
+    relayServer = new RelayServer(testRelayOpts({ baseUrl: "wss://relay.test.local" }));
+    sessions = new SessionStore(testSessionTtlMs);
+    // Use an inline PEM so tests do not touch disk.
+    const pair = generateKeyPairSync("ec", {
+      namedCurve: "prime256v1",
+      publicKeyEncoding: { type: "spki", format: "pem" },
+      privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    });
+    brokerKey = loadBrokerSigningKey({ BROKER_SIGNING_KEY: pair.privateKey }, "/tmp");
+
+    const app = express();
+    app.use(buildE2EMockRouter(relayServer, sessions, brokerKey, BASE_URL));
+
+    await new Promise<void>((resolve) => {
+      httpServer = app.listen(0, () => {
+        resolve();
+      });
+    });
+    const addr = httpServer.address();
+    if (addr === null || typeof addr === "string") throw new Error("No port");
+    httpPort = addr.port;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve, reject) => {
+      httpServer.close((err) => {
+        if (err !== undefined) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+    await relayServer.close();
+    sessions.clear();
+  });
+
+  // -------------------------------------------------------------------------
+  // /connect/mock
+  // -------------------------------------------------------------------------
+
+  describe("GET /connect/mock", () => {
+    it("valid session → 302 redirect to /callback/mock with synthetic token", async () => {
+      const sessionId = "550e8400-e29b-41d4-a716-446655440000";
+      const identity = generateSigningIdentity();
+      sessions.set({
+        sessionId,
+        relayUuid: identity.uuid,
+        pubkey: identity.decryptPubkeyBytes,
+        pkceChallenge: "challenge",
+        provider: MOCK_PROVIDER_KEY,
+        expiresAt: Date.now() + 60_000,
+      });
+
+      const response = await fetch(
+        `http://localhost:${httpPort.toString()}/connect/mock?state=${sessionId}`,
+        { redirect: "manual" },
+      );
+
+      expect(response.status).toBe(302);
+      const location = response.headers.get("location");
+      expect(location).not.toBeNull();
+      const url = new URL(location ?? "");
+      expect(url.origin + url.pathname).toBe(`${BASE_URL}/callback/mock`);
+      expect(url.searchParams.get("state")).toBe(sessionId);
+      expect(url.searchParams.get("access_token")).toBe(`mock-token-${sessionId}`);
+      expect(url.searchParams.get("token_type")).toBe("bearer");
+    });
+
+    it("missing state → 400", async () => {
+      const response = await fetch(`http://localhost:${httpPort.toString()}/connect/mock`);
+      expect(response.status).toBe(400);
+    });
+
+    it("unknown state → 400", async () => {
+      const response = await fetch(
+        `http://localhost:${httpPort.toString()}/connect/mock?state=does-not-exist`,
+      );
+      expect(response.status).toBe(400);
+    });
+
+    it("session for a non-mock provider → 400", async () => {
+      const sessionId = "aa0e8400-e29b-41d4-a716-446655440000";
+      const identity = generateSigningIdentity();
+      sessions.set({
+        sessionId,
+        relayUuid: identity.uuid,
+        pubkey: identity.decryptPubkeyBytes,
+        pkceChallenge: "challenge",
+        provider: "github",
+        expiresAt: Date.now() + 60_000,
+      });
+
+      const response = await fetch(
+        `http://localhost:${httpPort.toString()}/connect/mock?state=${sessionId}`,
+      );
+      expect(response.status).toBe(400);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // /_test/deliver
+  // -------------------------------------------------------------------------
+
+  describe("POST /_test/deliver", () => {
+    it("missing fields → 400", async () => {
+      const response = await fetch(`http://localhost:${httpPort.toString()}/_test/deliver`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ uuid: "x" }),
+      });
+      expect(response.status).toBe(400);
+    });
+
+    it("unknown daemon uuid → 404", async () => {
+      const response = await fetch(`http://localhost:${httpPort.toString()}/_test/deliver`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          uuid: "a".repeat(64),
+          session_id: randomBytes(16).toString("hex"),
+          provider: "github",
+          tokens: { access_token: "t" },
+        }),
+      });
+      expect(response.status).toBe(404);
+    });
+
+    it("connected daemon → encrypts + signs + forwards; daemon can verify sig", async () => {
+      const identity = generateSigningIdentity();
+      const ws = await connectDaemon(relayServer.port, identity);
+
+      // Capture the request message that arrives at the daemon end.
+      const forwarded: RequestMessage[] = [];
+      ws.on("message", (data: Buffer | string) => {
+        const msg = JSON.parse(typeof data === "string" ? data : data.toString()) as Record<
+          string,
+          unknown
+        >;
+        if (msg.type === "request") {
+          forwarded.push(msg as unknown as RequestMessage);
+          const req = msg as RequestMessage;
+          const response: ResponseMessage = {
+            type: "response",
+            id: req.id,
+            status: 200,
+            headers: {},
+            body: Buffer.from("ok").toString("base64"),
+          };
+          ws.send(JSON.stringify(response));
+        }
+      });
+
+      const sessionId = randomBytes(16).toString("hex");
+      const response = await fetch(`http://localhost:${httpPort.toString()}/_test/deliver`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          uuid: identity.uuid,
+          session_id: sessionId,
+          provider: "github",
+          tokens: { access_token: "test-token" },
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(forwarded).toHaveLength(1);
+      expect(forwarded[0]?.path).toBe("/hooks/oauth-complete");
+
+      const bodyJson = JSON.parse(
+        Buffer.from(forwarded[0]?.body ?? "", "base64").toString("utf8"),
+      ) as {
+        type: string;
+        session_id: string;
+        ephemeral_pubkey: string;
+        ciphertext: string;
+        nonce: string;
+        broker_sig: string;
+      };
+      expect(bodyJson.type).toBe("oauth_token_delivery");
+      expect(bodyJson.session_id).toBe(sessionId);
+      expect(
+        verifyDeliverySignature(
+          brokerKey.publicKeyBase64,
+          bodyJson.broker_sig,
+          bodyJson.type,
+          bodyJson.session_id,
+          bodyJson.ephemeral_pubkey,
+          bodyJson.ciphertext,
+          bodyJson.nonce,
+        ),
+      ).toBe(true);
+
+      ws.close();
+    });
+  });
+});

--- a/tests/broker/e2e-mock.test.ts
+++ b/tests/broker/e2e-mock.test.ts
@@ -425,6 +425,15 @@ describe("isE2EMockEnabled", () => {
     process.env.NODE_ENV = "production";
     expect(isE2EMockEnabled()).toBe(false);
   });
+
+  it.each(["PRODUCTION", "Production", " production", "production ", "  PRODUCTION  "])(
+    "still fails closed for oddly-cased/whitespaced NODE_ENV %p",
+    (val) => {
+      process.env.DICODE_E2E_MOCK_PROVIDER = "1";
+      process.env.NODE_ENV = val;
+      expect(isE2EMockEnabled()).toBe(false);
+    },
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/broker/e2e-mock.test.ts
+++ b/tests/broker/e2e-mock.test.ts
@@ -11,7 +11,11 @@ import type { Server } from "node:http";
 import express from "express";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { WebSocket } from "ws";
-import { buildE2EMockRouter, MOCK_PROVIDER_KEY } from "../../src/broker/e2e-mock.js";
+import {
+  buildE2EMockRouter,
+  isE2EMockEnabled,
+  MOCK_PROVIDER_KEY,
+} from "../../src/broker/e2e-mock.js";
 import { SessionStore } from "../../src/broker/sessions.js";
 import { verifyDeliverySignature } from "../../src/broker/signing.js";
 import type { BrokerSigningKey } from "../../src/broker/signing.js";
@@ -19,8 +23,6 @@ import { loadBrokerSigningKey } from "../../src/broker/signing.js";
 import { RelayServer } from "../../src/relay/server.js";
 import type { RequestMessage, ResponseMessage } from "../../src/relay/protocol.js";
 import { testRelayOpts, testSessionTtlMs } from "../helpers.js";
-
-const BASE_URL = "https://relay.test.local";
 
 // ---------------------------------------------------------------------------
 // Shared helpers
@@ -135,7 +137,7 @@ describe("E2E mock router", () => {
     brokerKey = loadBrokerSigningKey({ BROKER_SIGNING_KEY: pair.privateKey }, "/tmp");
 
     const app = express();
-    app.use(buildE2EMockRouter(relayServer, sessions, brokerKey, BASE_URL));
+    app.use(buildE2EMockRouter(relayServer, sessions, brokerKey));
 
     await new Promise<void>((resolve) => {
       httpServer = app.listen(0, () => {
@@ -186,11 +188,31 @@ describe("E2E mock router", () => {
       expect(response.status).toBe(302);
       const location = response.headers.get("location");
       expect(location).not.toBeNull();
-      const url = new URL(location ?? "");
-      expect(url.origin + url.pathname).toBe(`${BASE_URL}/callback/mock`);
+      // Relative redirect — matches router.ts style. Parse against a dummy
+      // base so URL semantics still work.
+      const url = new URL(location ?? "", "http://dummy.local");
+      expect(url.pathname).toBe("/callback/mock");
       expect(url.searchParams.get("state")).toBe(sessionId);
       expect(url.searchParams.get("access_token")).toBe(`mock-token-${sessionId}`);
       expect(url.searchParams.get("token_type")).toBe("bearer");
+    });
+
+    it("expired session → 400", async () => {
+      const sessionId = "bb0e8400-e29b-41d4-a716-446655440000";
+      const identity = generateSigningIdentity();
+      sessions.set({
+        sessionId,
+        relayUuid: identity.uuid,
+        pubkey: identity.decryptPubkeyBytes,
+        pkceChallenge: "challenge",
+        provider: MOCK_PROVIDER_KEY,
+        expiresAt: Date.now() - 1,
+      });
+
+      const response = await fetch(
+        `http://localhost:${httpPort.toString()}/connect/mock?state=${sessionId}`,
+      );
+      expect(response.status).toBe(400);
     });
 
     it("missing state → 400", async () => {
@@ -293,6 +315,12 @@ describe("E2E mock router", () => {
       expect(forwarded).toHaveLength(1);
       expect(forwarded[0]?.path).toBe("/hooks/oauth-complete");
 
+      // The caller sees ONLY the daemon's status — the decoded daemon body
+      // must not be reflected back (unauthenticated echo reducer).
+      const respJson = (await response.json()) as Record<string, unknown>;
+      expect(respJson).toEqual({ daemon_status: 200 });
+      expect(respJson).not.toHaveProperty("daemon_body");
+
       const bodyJson = JSON.parse(
         Buffer.from(forwarded[0]?.body ?? "", "base64").toString("utf8"),
       ) as {
@@ -319,5 +347,132 @@ describe("E2E mock router", () => {
 
       ws.close();
     });
+
+    it("rejects tokens=null as 400 (typeof null === 'object' quirk)", async () => {
+      const response = await fetch(`http://localhost:${httpPort.toString()}/_test/deliver`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          uuid: "a".repeat(64),
+          session_id: "x",
+          provider: "github",
+          tokens: null,
+        }),
+      });
+      expect(response.status).toBe(400);
+    });
+
+    it("rejects tokens=[] as 400 (array is not a plain object)", async () => {
+      const response = await fetch(`http://localhost:${httpPort.toString()}/_test/deliver`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          uuid: "a".repeat(64),
+          session_id: "x",
+          provider: "github",
+          tokens: [],
+        }),
+      });
+      expect(response.status).toBe(400);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isE2EMockEnabled()
+// ---------------------------------------------------------------------------
+
+describe("isE2EMockEnabled", () => {
+  const savedFlag = process.env.DICODE_E2E_MOCK_PROVIDER;
+  const savedNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    if (savedFlag === undefined) {
+      delete process.env.DICODE_E2E_MOCK_PROVIDER;
+    } else {
+      process.env.DICODE_E2E_MOCK_PROVIDER = savedFlag;
+    }
+    if (savedNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = savedNodeEnv;
+    }
+  });
+
+  it("returns false when env var unset", () => {
+    delete process.env.DICODE_E2E_MOCK_PROVIDER;
+    delete process.env.NODE_ENV;
+    expect(isE2EMockEnabled()).toBe(false);
+  });
+
+  it("returns true when env var is exactly '1'", () => {
+    process.env.DICODE_E2E_MOCK_PROVIDER = "1";
+    delete process.env.NODE_ENV;
+    expect(isE2EMockEnabled()).toBe(true);
+  });
+
+  it.each(["true", "TRUE", "yes", "on", "0", " 1", "1 ", ""])(
+    "returns false for non-'1' value %p",
+    (val) => {
+      process.env.DICODE_E2E_MOCK_PROVIDER = val;
+      delete process.env.NODE_ENV;
+      expect(isE2EMockEnabled()).toBe(false);
+    },
+  );
+
+  it("returns false when NODE_ENV=production even if flag='1' (fail-closed in prod)", () => {
+    process.env.DICODE_E2E_MOCK_PROVIDER = "1";
+    process.env.NODE_ENV = "production";
+    expect(isE2EMockEnabled()).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Routes absent when the e2e-mock router is NOT mounted
+// ---------------------------------------------------------------------------
+
+describe("mock routes absent when flag unset", () => {
+  let httpServer: Server;
+  let httpPort: number;
+
+  beforeEach(async () => {
+    // Simulate index.ts's behavior when DICODE_E2E_MOCK_PROVIDER is off:
+    // the e2e-mock router is simply never mounted.
+    const app = express();
+    app.use(express.json());
+    await new Promise<void>((resolve) => {
+      httpServer = app.listen(0, () => {
+        resolve();
+      });
+    });
+    const addr = httpServer.address();
+    if (addr === null || typeof addr === "string") throw new Error("No port");
+    httpPort = addr.port;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve, reject) => {
+      httpServer.close((err) => {
+        if (err !== undefined) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+  });
+
+  it("GET /connect/mock → 404", async () => {
+    const response = await fetch(`http://localhost:${httpPort.toString()}/connect/mock?state=x`);
+    expect(response.status).toBe(404);
+  });
+
+  it("POST /_test/deliver → 404", async () => {
+    const response = await fetch(`http://localhost:${httpPort.toString()}/_test/deliver`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(response.status).toBe(404);
   });
 });


### PR DESCRIPTION
## Summary

Closes #31. Adds a mock OAuth provider that short-circuits the upstream authorize + token-exchange steps, so CI / integration tests can exercise the full daemon-issued `build_auth_url` → broker → daemon token-delivery round-trip without any real OAuth credentials.

Two endpoints, both gated behind `DICODE_E2E_MOCK_PROVIDER=1` (a WARN is logged at startup, same mount-before-Grant pattern the issue spec describes):

- **`GET /connect/mock`** — reads the session created by `/auth/mock`, redirects the browser to `/callback/mock?state=…&access_token=mock-token-<session>&token_type=bearer`. The existing `/callback/:provider` handler then encrypts + signs + forwards to the daemon. This is the flow acceptance criteria #2–#4 describe.
- **`POST /_test/deliver`** — lower-level primitive that bypasses `/auth` and `/connect` entirely. Takes `{uuid, session_id, provider, tokens}` directly and exercises the encrypt + sign + forward path. This is the endpoint that uncovered dicode-core#151 (broker-sig hash-depth mismatch) and is worth keeping around for cross-implementation wire-shape testing.

`mock` is registered in `brokerProviders` so `/auth/mock` passes the provider-exists check, but deliberately excluded from the Grant config (option 2 in the issue spec) — Grant never tries to dispatch `/connect/mock` upstream.

## Acceptance-criteria coverage (from #31)

- [x] `mock` provider registers only when `DICODE_E2E_MOCK_PROVIDER=1`
- [x] Daemon's OAuth IPC → `/auth/mock` is accepted (provider map gating)
- [x] Opening the daemon-issued URL round-trips to an ECIES-encrypted token delivery
- [x] Daemon's `DecryptOAuthToken` sees `mock-token-<sessionId>` (validated E2E against a real dicode-core daemon when the broker-sig fix in dicode-core#152 landed)
- [x] Startup prints bright WARN when the flag is on
- [ ] Docker image asserts flag is OFF by default — left as a follow-up; worth a CI step in `.github/workflows/ci.yml` once the test suite covers more docker-related checks

## Test plan

- [x] `npm run typecheck && npm run lint && npm run format:check && npm run test` — all green (110/110)
- [x] New test file `tests/broker/e2e-mock.test.ts` covers:
  - `/connect/mock` valid session → 302 with synthetic token
  - `/connect/mock` missing / unknown / non-mock-provider state → 400
  - `/_test/deliver` missing fields → 400
  - `/_test/deliver` unknown daemon uuid → 404
  - `/_test/deliver` connected daemon → encrypts + signs + forwards; the delivery sig verifies against `brokerKey.publicKeyBase64`
- [x] Manually exercised against a live dicode-core daemon during dicode-core#151/#152 investigation — secrets (`GITHUB_ACCESS_TOKEN`, `GITHUB_REFRESH_TOKEN`, `GITHUB_SCOPE`, `GITHUB_TOKEN_TYPE`) correctly written on the daemon side after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)