### PR TITLE
ci: dual-publish Docker image to Docker Hub + ghcr.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4
         with:
@@ -36,11 +42,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract version from tag
+      # Dual-publish to Docker Hub (primary, user-facing) and ghcr.io
+      # (secondary, co-located with the git repo). metadata-action fans
+      # the same tag set across both images so a single build-push step
+      # pushes both.
+      - name: Extract image tags
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ghcr.io/dicode-ayo/dicode-relay
+          images: |
+            docker.io/dicode/dicode-relay
+            ghcr.io/dicode-ayo/dicode-relay
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -77,6 +89,8 @@ jobs:
             ## Docker image
 
             ```
+            docker pull dicode/dicode-relay:${{ steps.meta.outputs.version }}
+            # or, from GitHub's registry
             docker pull ghcr.io/dicode-ayo/dicode-relay:${{ steps.meta.outputs.version }}
             ```
 

--- a/README.md
+++ b/README.md
@@ -74,9 +74,11 @@ npm run dev
 ### Docker
 
 ```sh
-docker pull ghcr.io/dicode-ayo/dicode-relay:latest
-docker run -p 5553:5553 --env-file .env ghcr.io/dicode-ayo/dicode-relay:latest
+docker pull dicode/dicode-relay
+docker run -p 5553:5553 --env-file .env dicode/dicode-relay
 ```
+
+Also mirrored at `ghcr.io/dicode-ayo/dicode-relay` if you prefer to pull from GitHub's registry.
 
 ---
 


### PR DESCRIPTION
## Summary

Extend the release workflow to publish Docker images to **Docker Hub** (namespace: `dicode`, canonical public-discovery registry) in addition to the existing `ghcr.io/dicode-ayo/dicode-relay` mirror. One build, two push targets.

## Changes

- **`.github/workflows/release.yml`** — adds a `docker/login-action@v4` step for `docker.io`, has `docker/metadata-action@v6` emit tags for both images in one pass, and the existing `docker/build-push-action@v7` pushes both. Release-notes body leads with `docker pull dicode/dicode-relay:<ver>` and mentions ghcr as an alternative.
- **`README.md`** — `### Docker` section now points at `docker.io/dicode/dicode-relay`.

## ⚠️ Before the next release tag fires

**One-time setup** — I don't have Docker Hub or repo-secret access:

1. Create a Docker Hub **access token** with Read/Write/Delete scope on `dicode/dicode-relay` at https://hub.docker.com/settings/security
2. Add two repo secrets:
   - `DOCKERHUB_USERNAME` — the Docker Hub account that has publish rights on the `dicode` org
   - `DOCKERHUB_TOKEN` — the access token
3. Make sure the `dicode/dicode-relay` repository exists on Docker Hub (Docker Hub auto-creates on first push, but you can pre-create it if you want a description / README sync).

The "Context access might be invalid" IDE warnings clear once the secrets are set.

## Merge ordering

This sits on top of #33 (already merged). Once merged, the next release-please tag will publish both Docker images + npm in one go.

## Test plan

- [ ] Add `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` secrets
- [ ] Merge the next release-please PR so a `v*.*.*` tag fires
- [ ] Confirm both `docker pull dicode/dicode-relay:<version>` and `docker pull ghcr.io/dicode-ayo/dicode-relay:<version>` resolve
- [ ] Confirm the GitHub Release body shows both registry examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)