### PR TITLE
ci: switch Docker Hub namespace to dicodeayo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: |
-            docker.io/dicode/dicode-relay
+            docker.io/dicodeayo/dicode-relay
             ghcr.io/dicode-ayo/dicode-relay
           tags: |
             type=semver,pattern={{version}}
@@ -89,7 +89,7 @@ jobs:
             ## Docker image
 
             ```
-            docker pull dicode/dicode-relay:${{ steps.meta.outputs.version }}
+            docker pull dicodeayo/dicode-relay:${{ steps.meta.outputs.version }}
             # or, from GitHub's registry
             docker pull ghcr.io/dicode-ayo/dicode-relay:${{ steps.meta.outputs.version }}
             ```

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ npm run dev
 ### Docker
 
 ```sh
-docker pull dicode/dicode-relay
-docker run -p 5553:5553 --env-file .env dicode/dicode-relay
+docker pull dicodeayo/dicode-relay
+docker run -p 5553:5553 --env-file .env dicodeayo/dicode-relay
 ```
 
 Also mirrored at `ghcr.io/dicode-ayo/dicode-relay` if you prefer to pull from GitHub's registry.


### PR DESCRIPTION
## Summary

The `dicode` Docker Hub namespace was already taken, falling back to `dicodeayo` to mirror the GitHub org name (ghcr allows hyphens — `dicode-ayo` — Docker Hub doesn't, so we drop the hyphen on that side).

One-line swap in `release.yml` (image tag list + release-notes body) and `README.md` (Docker install block). 4 lines each file.

## Before next release

`DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` secrets need to point at a Docker Hub account that has publish rights on the `dicodeayo` org + the `dicodeayo/dicode-relay` repo (per-repo token scope recommended).

## Test plan

- [ ] Small enough to eyeball — no tests
- [ ] Next release-please tag push should publish to `dicodeayo/dicode-relay` on Docker Hub + `ghcr.io/dicode-ayo/dicode-relay` on ghcr

🤖 Generated with [Claude Code](https://claude.com/claude-code)