### PR TITLE
chore: prepare repo for public release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,8 +24,8 @@ reproduced in full in the protocol spec below — do not deviate from it.
 
 ## Design document
 
-Read `/home/dr14/dicode/docs/design/oauth-broker.md` in full before writing
-any code. It contains:
+Read the OAuth broker design document in the dicode-core repository
+(`docs/design/oauth-broker.md`) in full before writing any code. It contains:
 - Architecture diagram
 - Step-by-step flow with sequence diagram
 - Full security design (ECDSA sig verification, ECIES token encryption, PKCE binding, replay prevention)

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ See [docs/providers.md](docs/providers.md) for the full ECIES decryption procedu
 - **Single-use sessions**: Sessions are deleted immediately after the token is delivered. Replay attacks require re-running the full OAuth flow.
 - **Timestamp + nonce replay prevention**: Auth requests must be within ±30 s of server time. Relay handshake nonces are tracked for 60 s.
 
-See [docs/design/oauth-broker.md](../dicode/docs/design/oauth-broker.md) for the full threat model.
+See the OAuth broker design document in the dicode-core repository for the full threat model.
 
 ---
 
@@ -214,14 +214,15 @@ See [docs/design/oauth-broker.md](../dicode/docs/design/oauth-broker.md) for the
 ### Docker (recommended)
 
 ```sh
-docker build -t dicode-relay .
 docker run -d \
   -p 5553:5553 \
   -e BASE_URL=https://relay.dicode.app \
   -e GITHUB_CLIENT_ID=xxx \
   -e GITHUB_CLIENT_SECRET=yyy \
-  dicode-relay
+  dicodeayo/dicode-relay
 ```
+
+Also available at `ghcr.io/dicode-ayo/dicode-relay` if you prefer GitHub's registry.
 
 ### Cloudflare
 


### PR DESCRIPTION
## Summary

Three small docs cleanups from the pre-public-flip audit. No runtime code changed; 131/131 tests still passing.

- **[README.md#L208]** broken cross-repo link — `[docs/design/oauth-broker.md](../dicode/docs/design/oauth-broker.md)` only resolves in a monorepo-style local checkout. Swapped for plain text pointing at dicode-core so we don't ship a 404 link.
- **[README.md#L212-L224]** deployment Docker section modernized — was running `docker build -t dicode-relay .` from source while the Install section above already pulls from Docker Hub. Both sections now consistently use `dicodeayo/dicode-relay`.
- **[CLAUDE.md#L27]** `/home/dr14/dicode/…` leaked a developer's local username. Replaced with a repo-relative reference to dicode-core's docs.

Additional sanity passes run:
- Grep for `/home/`, `/Users/`, `../dicode` patterns repo-wide: nothing else.
- `.gitignore` already covers `relay.yaml`, `broker-signing-key.pem`, `.env*`. No tracked secrets.

## Test plan

- [x] `npm run format:check` — clean
- [x] `npm run test` — 131/131 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)