### PR TITLE
ci: use PAT for release-please-action so tag pushes fire release.yml

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,20 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # Explicit PAT instead of the default GITHUB_TOKEN. GitHub deliberately
+      # blocks workflow_run cascades driven by GITHUB_TOKEN to prevent infinite
+      # recursion: when release-please creates the `v*.*.*` tag using the
+      # default token, the tag-push event does NOT trigger `release.yml`. A
+      # user-owned PAT (or a GitHub App install token) bypasses that block,
+      # so the release workflow fires naturally and publishes to npm / Docker
+      # Hub / ghcr without any manual tag-push surgery.
+      #
+      # Required scope on the PAT (fine-grained):
+      #   - Contents: Read & write
+      #   - Pull requests: Read & write
+      # Classic PAT equivalent: `repo` scope.
       - uses: googleapis/release-please-action@v4
         with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary

Fix the root cause of the v0.1.1 publish stall. One-line workflow change.

## The bug

GitHub Actions deliberately blocks workflow_run cascades driven by the default `GITHUB_TOKEN`, to prevent infinite recursion. When release-please-action merges its release PR and creates the `v*.*.*` tag using GITHUB_TOKEN, the tag-push event **does not** trigger our `release.yml` workflow — which is exactly what happened on v0.1.1, requiring a manual tag-delete-and-re-push to unstick the publish pipeline.

## The fix

Pass a user-owned PAT (`RELEASE_PLEASE_TOKEN`) via the `token:` input on `googleapis/release-please-action@v4`. PAT-authored pushes bypass the cascade block, so `release.yml` fires naturally on every merged release PR.

## ⚠️ Before the next release

Add the `RELEASE_PLEASE_TOKEN` repo secret. Choose one:

**Fine-grained PAT (recommended):** https://github.com/settings/personal-access-tokens/new
- Repository access: only `dicode-ayo/dicode-relay`
- Permissions:
  - Contents: Read and write
  - Pull requests: Read and write

**Classic PAT:** `repo` scope. Broader blast radius — use fine-grained if you can.

Until the secret is set, `${{ secrets.RELEASE_PLEASE_TOKEN }}` resolves to an empty string and release-please-action falls back to the default GITHUB_TOKEN, which means we'd repeat the v0.1.1 dance. Set the secret before merging the next release-please PR.

## Future upgrade path

For multi-maintainer hygiene, swap the PAT for a GitHub App install token (no rotation burden, not tied to a user leaving the org). Out of scope here — follow-up candidate.

## Test plan

- [ ] Add `RELEASE_PLEASE_TOKEN` secret
- [ ] Merge this PR
- [ ] Land the next conventional-commit-bumping change on main → release-please opens `0.1.2` PR
- [ ] Merge the release PR → confirm `release.yml` fires automatically (not stuck like v0.1.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)