### PR TITLE
fix(broker): scope json() to /_test/deliver so hook bodies aren't eaten

### DIFF
--- a/src/broker/e2e-mock.ts
+++ b/src/broker/e2e-mock.ts
@@ -74,13 +74,17 @@ export function buildE2EMockRouter(
   brokerKey: BrokerSigningKey,
 ): Router {
   const router: Router = makeRouter();
-  router.use(json());
 
   router.get("/connect/mock", (req: Request, res: Response) => {
     handleConnectMock(req, res, sessions);
   });
 
-  router.post("/_test/deliver", (req: Request, res: Response) => {
+  // Scope json() to this specific route. `router.use(json())` would apply
+  // to every request the router sees — and since the router is mounted at
+  // the app root (to run before Grant), it'd consume JSON bodies on
+  // unrelated routes like /u/:uuid/hooks/*, silently dropping webhook
+  // payloads that carry Content-Type: application/json.
+  router.post("/_test/deliver", json(), (req: Request, res: Response) => {
     void handleDeliver(req, res, relay, brokerKey);
   });
 

--- a/tests/broker/e2e-mock.test.ts
+++ b/tests/broker/e2e-mock.test.ts
@@ -485,3 +485,88 @@ describe("mock routes absent when flag unset", () => {
     expect(response.status).toBe(404);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Regression: the e2e-mock router must NOT globally consume JSON bodies
+// ---------------------------------------------------------------------------
+//
+// The router mounts at the app root (so /connect/mock gets intercepted
+// before Grant). Until this guard was added, `router.use(json())` caused
+// every `application/json` request — including unrelated webhook forwards
+// like /u/:uuid/hooks/* — to have its body eaten by the mock router's
+// json middleware before reaching the actual forward handler. Bodies
+// silently arrived empty downstream.
+//
+// This test mounts the e2e-mock router alongside a raw-body POST handler
+// on an unrelated path and confirms the body flows through intact with
+// Content-Type: application/json.
+
+describe("e2e-mock router body-passthrough on unrelated routes", () => {
+  let httpServer: Server;
+  let httpPort: number;
+  let relayServer: RelayServer;
+  let sessions: SessionStore;
+  let brokerKey: BrokerSigningKey;
+
+  beforeEach(async () => {
+    relayServer = new RelayServer(testRelayOpts({ baseUrl: "wss://relay.test.local" }));
+    sessions = new SessionStore(testSessionTtlMs);
+    const pair = generateKeyPairSync("ec", {
+      namedCurve: "prime256v1",
+      publicKeyEncoding: { type: "spki", format: "pem" },
+      privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    });
+    brokerKey = loadBrokerSigningKey({ BROKER_SIGNING_KEY: pair.privateKey }, "/tmp");
+
+    const app = express();
+    // Mount the e2e-mock router FIRST (same order as src/index.ts when the
+    // flag is on) — this is the configuration we're guarding against.
+    app.use(buildE2EMockRouter(relayServer, sessions, brokerKey));
+    // A simple downstream handler that reads the raw body — stands in for
+    // the /u/:uuid/hooks/* forward handler in src/index.ts.
+    app.post(
+      "/raw-echo",
+      express.raw({ type: "*/*", limit: "5mb" }),
+      (req: express.Request, res: express.Response) => {
+        const body = Buffer.isBuffer(req.body) ? req.body : Buffer.alloc(0);
+        res.status(200).json({ length: body.length, body: body.toString("utf8") });
+      },
+    );
+
+    await new Promise<void>((resolve) => {
+      httpServer = app.listen(0, () => {
+        resolve();
+      });
+    });
+    const addr = httpServer.address();
+    if (addr === null || typeof addr === "string") throw new Error("No port");
+    httpPort = addr.port;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve, reject) => {
+      httpServer.close((err) => {
+        if (err !== undefined) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+    await relayServer.close();
+    sessions.clear();
+  });
+
+  it("application/json POST body on an unrelated route reaches the downstream raw handler", async () => {
+    const payload = JSON.stringify({ hello: "world" });
+    const response = await fetch(`http://localhost:${httpPort.toString()}/raw-echo`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: payload,
+    });
+    expect(response.status).toBe(200);
+    const seen = (await response.json()) as { length: number; body: string };
+    expect(seen.length).toBe(payload.length);
+    expect(seen.body).toBe(payload);
+  });
+});


### PR DESCRIPTION
## Summary

Fix a body-dropping bug in the e2e-mock router (PR #32) surfaced while building the dicode-core#137 testcontainers e2e suite.

## The bug

[buildE2EMockRouter](src/broker/e2e-mock.ts#L71-L88) called \`router.use(json())\` at the top of the router. Because the router is mounted at the app root (required — it has to intercept \`/connect/mock\` before Grant), that \`json()\` middleware ran on every request the router saw, **including unrelated \`/u/:uuid/hooks/*\` webhook forwards**. \`application/json\` bodies were consumed by \`json()\` before the actual forward handler's \`express.raw()\` could read them, so webhook payloads silently arrived empty at connected daemons.

## Prod impact: zero

\`isE2EMockEnabled()\` requires \`DICODE_E2E_MOCK_PROVIDER=1\` **and** fails closed under \`NODE_ENV=production\`. The shipped Dockerfile bakes in \`NODE_ENV=production\`, so a deployed container never mounts the router. Dev environments and the e2e test harness (which explicitly sets \`NODE_ENV=test\`) are the only places the bug can reach.

## Fix

Apply \`json()\` only to the \`/_test/deliver\` route (which actually needs to parse a JSON body). \`/connect/mock\` is a GET so doesn't need it.

## Regression test

\`tests/broker/e2e-mock.test.ts\` gains a \"body-passthrough on unrelated routes\" suite that mounts the e2e-mock router alongside a raw-body POST handler on an unrelated path and asserts an \`application/json\` body flows through intact. Verified the test **fails** without this fix (1 failed / 28 passed after reverting the src change), **passes** with it (132/132 green).

## Test plan

- [x] \`npm run typecheck && npm run lint && npm run format:check && npm run test\` — 132/132 green
- [x] Regression test verified to catch the bug (fails on unpatched src)
- [ ] After merge + release 0.1.2, bump the dicode-core e2e test's \`Dockerfile.relay\` \`FROM\` line to \`0.1.2\` → the suite (issue dicode-core#137) starts passing with realistic \`application/json\` content types

🤖 Generated with [Claude Code](https://claude.com/claude-code)