### PR TITLE
security(status): use timingSafeEqual for dashboard password compare

### DIFF
--- a/src/status/auth.ts
+++ b/src/status/auth.ts
@@ -1,3 +1,5 @@
+import { timingSafeEqual } from "node:crypto";
+
 import type { RequestHandler } from "express";
 
 export function statusAuth(password: string | undefined): RequestHandler {
@@ -25,7 +27,9 @@ export function statusAuth(password: string | undefined): RequestHandler {
     const colonIndex = decoded.indexOf(":");
     const providedPassword = colonIndex === -1 ? decoded : decoded.substring(colonIndex + 1);
 
-    if (providedPassword !== password) {
+    const provided = Buffer.from(providedPassword, "utf8");
+    const expected = Buffer.from(password, "utf8");
+    if (provided.length !== expected.length || !timingSafeEqual(provided, expected)) {
       res.status(401).json({ error: "invalid credentials" });
       return;
     }

--- a/tests/status/auth.test.ts
+++ b/tests/status/auth.test.ts
@@ -68,4 +68,22 @@ describe("statusAuth middleware", () => {
     const body = (await res.json()) as { ok: boolean };
     expect(body.ok).toBe(true);
   });
+
+  it("rejects wrong password of different length without throwing", async () => {
+    const { port, server: s } = await startApp("secret123");
+    server = s;
+    const res = await fetch(`http://localhost:${port.toString()}/test`, {
+      headers: { authorization: basicAuthHeader("x") },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects wrong password of equal length", async () => {
+    const { port, server: s } = await startApp("secret123");
+    server = s;
+    const res = await fetch(`http://localhost:${port.toString()}/test`, {
+      headers: { authorization: basicAuthHeader("xxxxxxxxx") },
+    });
+    expect(res.status).toBe(401);
+  });
 });


### PR DESCRIPTION
Closes #47

## Summary
- Replace short-circuit `!==` string compare in `src/status/auth.ts:28` with `crypto.timingSafeEqual` on equal-length buffers.
- Keep an explicit length-mismatch guard before `timingSafeEqual` (which throws on unequal lengths). This leaks only the password length — a fixed configured constant, not secret material.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npm test tests/status/auth.test.ts` — 6 tests pass, including new cases for wrong-password-same-length and wrong-password-different-length