### PR TITLE
security(broker): allowlist OAuth response fields before encryption

### DIFF
--- a/src/broker/router.ts
+++ b/src/broker/router.ts
@@ -53,9 +53,7 @@ const ALLOWED_TOKEN_FIELDS_SET = new Set<string>(ALLOWED_TOKEN_FIELDS);
 export function filterCallbackTokenFields(
   raw: Record<string, unknown>,
 ): Partial<Record<AllowedTokenField, unknown>> {
-  return Object.fromEntries(
-    Object.entries(raw).filter(([k]) => ALLOWED_TOKEN_FIELDS_SET.has(k)),
-  );
+  return Object.fromEntries(Object.entries(raw).filter(([k]) => ALLOWED_TOKEN_FIELDS_SET.has(k)));
 }
 
 /**

--- a/src/broker/router.ts
+++ b/src/broker/router.ts
@@ -20,6 +20,43 @@ import type { OAuthTokenDeliveryPayload } from "../relay/protocol.js";
 import { buildDeliverySignaturePayload, type BrokerSigningKey } from "./signing.js";
 
 /**
+ * Fields that may be forwarded from an OAuth callback into the encrypted
+ * token delivery payload sent to the daemon.
+ *
+ * Rationale: the callback URL is attacker-reachable — any query param an
+ * upstream provider leaves through (or an open redirect/malicious upstream
+ * injects) would otherwise be JSON-encoded, encrypted to the daemon, and
+ * stored alongside the real token. We allowlist the OAuth 2.0 response
+ * parameters from RFC 6749 §5.1 plus the standard OIDC `id_token` and
+ * Grant's `raw` convenience field (the unmodified provider response body).
+ * Everything else — including `state`, provider error fields, and any
+ * unknown keys — is dropped before encryption.
+ */
+export const ALLOWED_TOKEN_FIELDS = [
+  "access_token",
+  "refresh_token",
+  "token_type",
+  "expires_in",
+  "scope",
+  "id_token",
+  "raw",
+] as const;
+
+type AllowedTokenField = (typeof ALLOWED_TOKEN_FIELDS)[number];
+
+/**
+ * Filter an OAuth callback's query parameters down to allowlisted token fields.
+ * Exported so it can be unit-tested without spinning up an Express server.
+ */
+export function filterCallbackTokenFields(
+  raw: Record<string, unknown>,
+): Partial<Record<AllowedTokenField, unknown>> {
+  return Object.fromEntries(
+    Object.entries(raw).filter(([k]) => (ALLOWED_TOKEN_FIELDS as readonly string[]).includes(k)),
+  ) as Partial<Record<AllowedTokenField, unknown>>;
+}
+
+/**
  * Build the Express router for the OAuth broker.
  *
  * @param relay               RelayServer instance
@@ -202,12 +239,11 @@ async function handleCallback(
     return;
   }
 
-  // Build the token payload (include all grant-returned fields)
-  // Remove state from token data to avoid leaking session metadata
-  const rawTokenData = req.query as Record<string, unknown>;
-  const tokensToDeliver = Object.fromEntries(
-    Object.entries(rawTokenData).filter(([k]) => k !== "state"),
-  );
+  // Build the token payload by allowlisting known OAuth response fields.
+  // The callback URL is attacker-reachable, so we must never ship the full
+  // `req.query` — unknown params (state, session metadata, injected junk)
+  // are dropped before encryption. See ALLOWED_TOKEN_FIELDS above.
+  const tokensToDeliver = filterCallbackTokenFields(req.query as Record<string, unknown>);
 
   // Encrypt the token payload with ECIES for the daemon. The message type
   // is bound into GCM's authenticated data so the daemon can never decrypt

--- a/src/broker/router.ts
+++ b/src/broker/router.ts
@@ -44,6 +44,8 @@ export const ALLOWED_TOKEN_FIELDS = [
 
 type AllowedTokenField = (typeof ALLOWED_TOKEN_FIELDS)[number];
 
+const ALLOWED_TOKEN_FIELDS_SET = new Set<string>(ALLOWED_TOKEN_FIELDS);
+
 /**
  * Filter an OAuth callback's query parameters down to allowlisted token fields.
  * Exported so it can be unit-tested without spinning up an Express server.
@@ -52,8 +54,8 @@ export function filterCallbackTokenFields(
   raw: Record<string, unknown>,
 ): Partial<Record<AllowedTokenField, unknown>> {
   return Object.fromEntries(
-    Object.entries(raw).filter(([k]) => (ALLOWED_TOKEN_FIELDS as readonly string[]).includes(k)),
-  ) as Partial<Record<AllowedTokenField, unknown>>;
+    Object.entries(raw).filter(([k]) => ALLOWED_TOKEN_FIELDS_SET.has(k)),
+  );
 }
 
 /**
@@ -243,7 +245,7 @@ async function handleCallback(
   // The callback URL is attacker-reachable, so we must never ship the full
   // `req.query` — unknown params (state, session metadata, injected junk)
   // are dropped before encryption. See ALLOWED_TOKEN_FIELDS above.
-  const tokensToDeliver = filterCallbackTokenFields(req.query as Record<string, unknown>);
+  const tokensToDeliver = filterCallbackTokenFields(req.query);
 
   // Encrypt the token payload with ECIES for the daemon. The message type
   // is bound into GCM's authenticated data so the daemon can never decrypt

--- a/tests/broker/callback-allowlist.test.ts
+++ b/tests/broker/callback-allowlist.test.ts
@@ -1,0 +1,74 @@
+/**
+ * OAuth callback allowlist — dicode-relay#44.
+ *
+ * The callback URL is attacker-reachable: a malicious upstream OAuth
+ * provider or an open-redirect exploited upstream could append extra
+ * query parameters. Before #44 those extras were JSON-encoded, ECIES-
+ * encrypted, and delivered to the daemon alongside the real token.
+ *
+ * The fix: allowlist the OAuth 2.0 RFC 6749 §5.1 response fields
+ * plus `id_token` (OIDC) and `raw` (Grant convenience). Everything
+ * else is dropped before encryption.
+ */
+
+import { describe, expect, it } from "vitest";
+import { ALLOWED_TOKEN_FIELDS, filterCallbackTokenFields } from "../../src/broker/router.js";
+
+describe("filterCallbackTokenFields", () => {
+  it("passes through standard OAuth response fields", () => {
+    const out = filterCallbackTokenFields({
+      access_token: "abc",
+      refresh_token: "def",
+      token_type: "Bearer",
+      expires_in: "3600",
+      scope: "user repo",
+      id_token: "oidc.jwt.here",
+      raw: { provider_specific: 1 },
+    });
+    expect(out).toEqual({
+      access_token: "abc",
+      refresh_token: "def",
+      token_type: "Bearer",
+      expires_in: "3600",
+      scope: "user repo",
+      id_token: "oidc.jwt.here",
+      raw: { provider_specific: 1 },
+    });
+  });
+
+  it("drops injected attacker-controlled fields", () => {
+    const out = filterCallbackTokenFields({
+      access_token: "real",
+      injected: "evil",
+      "x-admin": "true",
+      __proto__: "pollution",
+    });
+    expect(out).toEqual({ access_token: "real" });
+    expect("injected" in out).toBe(false);
+    expect("x-admin" in out).toBe(false);
+  });
+
+  it("drops the state field (it is session metadata, never a token)", () => {
+    const out = filterCallbackTokenFields({
+      state: "session-uuid",
+      access_token: "real",
+    });
+    expect(out).toEqual({ access_token: "real" });
+  });
+
+  it("handles empty input", () => {
+    expect(filterCallbackTokenFields({})).toEqual({});
+  });
+
+  it("ALLOWED_TOKEN_FIELDS matches RFC 6749 §5.1 + id_token + raw", () => {
+    expect(ALLOWED_TOKEN_FIELDS).toEqual([
+      "access_token",
+      "refresh_token",
+      "token_type",
+      "expires_in",
+      "scope",
+      "id_token",
+      "raw",
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #44

## Summary
Before this change, `handleCallback` in `src/broker/router.ts` forwarded the full `req.query` object (minus `state`) into the ECIES-encrypted token payload delivered to the daemon. Any callback-URL parameter an upstream provider leaves through — or that a malicious upstream / open-redirect injects — would be encrypted alongside the real token and stored in the daemon's secrets.

Now the callback handler explicitly allowlists the OAuth 2.0 RFC 6749 §5.1 response fields plus `id_token` (OIDC) and `raw` (Grant's convenience field with the unmodified provider response body). Everything else is dropped before encryption.

## Threat model
- Attacker-controllable upstream → can append arbitrary query params to the callback URL.
- Open redirect exploited at the provider → same effect.
- Without the allowlist, `?injected=evil` reaches the daemon's stored secrets.
- With the allowlist, only standard token fields survive.

## Implementation
- New exported `ALLOWED_TOKEN_FIELDS` constant + `filterCallbackTokenFields` helper in `src/broker/router.ts`.
- `handleCallback` now calls the helper; the old `filter(([k]) => k !== "state")` is gone.

## Test plan
- [x] New unit test `tests/broker/callback-allowlist.test.ts` (5 cases): standard fields pass through, injected fields dropped, state dropped, empty input, ALLOWED_TOKEN_FIELDS matches the spec.
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run format:check` clean