### PR TITLE
docs(proto): add npm proto script and align README with reality

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "format": "prettier --write src tests",
     "format:check": "prettier --check src tests",
     "typecheck": "tsc --noEmit",
+    "proto": "buf generate && prettier --write src/relay/pb",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

- `proto/README.md` (added in #57) tells contributors to run `npm run proto`, but no such script existed in `package.json`. Running the documented command failed.
- Added `"proto": "buf generate && prettier --write src/relay/pb"` so the docs work as written.
- Chaining prettier makes the script idempotent — running it on a clean tree produces no diff. Without it, `protoc-gen-es` emits unformatted code that doesn't match the prettier-formatted output committed in #57.

## Test plan

- [x] `npm run proto` succeeds
- [x] After `npm run proto` on a clean tree, `git status` shows no changes to `src/relay/pb/`
- [ ] CI green (lint / test / typecheck unaffected — package.json is the only file touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)