### PR TITLE
refactor(broker,status): adopt escape-html for HTML escaping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@bufbuild/protobuf": "^2.12.0",
+        "escape-html": "^1.0.3",
         "express": "^5.0.1",
         "express-basic-auth": "^1.2.1",
         "grant": "^5.4.22",
@@ -25,6 +26,7 @@
       "devDependencies": {
         "@bufbuild/protoc-gen-es": "^2.12.0",
         "@eslint/js": "^10.0.1",
+        "@types/escape-html": "^1.0.4",
         "@types/express": "^5.0.0",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^25.6.0",
@@ -1191,6 +1193,13 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/escape-html": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/escape-html/-/escape-html-1.0.4.tgz",
+      "integrity": "sha512-qZ72SFTgUAZ5a7Tj6kf2SHLetiH5S6f8G5frB2SPQ3EyF02kxdyBFf4Tz4banE3xCgGnKgWLt//a6VuYHKYJTg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.12.0",
+    "escape-html": "^1.0.3",
     "express": "^5.0.1",
     "express-basic-auth": "^1.2.1",
     "grant": "^5.4.22",
@@ -83,6 +84,7 @@
   "devDependencies": {
     "@bufbuild/protoc-gen-es": "^2.12.0",
     "@eslint/js": "^10.0.1",
+    "@types/escape-html": "^1.0.4",
     "@types/express": "^5.0.0",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.6.0",

--- a/src/broker/router.ts
+++ b/src/broker/router.ts
@@ -10,6 +10,7 @@
  * the relay WebSocket.
  */
 
+import escapeHtml from "escape-html";
 import { Router, type Request, type Response } from "express";
 import { v4 as uuidv4 } from "uuid";
 import type { RelayServer } from "../relay/server.js";
@@ -300,13 +301,4 @@ async function handleCallback(
       .status(503)
       .send("<html><body><p>Daemon not connected. Please retry the OAuth flow.</p></body></html>");
   }
-}
-
-function escapeHtml(str: string): string {
-  return str
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#x27;");
 }

--- a/src/status/page.ts
+++ b/src/status/page.ts
@@ -1,3 +1,4 @@
+import escapeHtml from "escape-html";
 import type { StatusSnapshot } from "./metrics.js";
 
 export function buildStatusJson(snapshot: StatusSnapshot): StatusSnapshot {
@@ -18,8 +19,8 @@ export function renderStatusPage(snapshot: StatusSnapshot): string {
       : clients
           .map(
             (c) => `<tr>
-          <td title="${esc(c.uuid)}">${esc(c.uuid.substring(0, 12))}...</td>
-          <td>${esc(c.connectedDuration)}</td>
+          <td title="${escapeHtml(c.uuid)}">${escapeHtml(c.uuid.substring(0, 12))}...</td>
+          <td>${escapeHtml(c.connectedDuration)}</td>
           <td>${c.reqPerSec.toString()} <span class="peak">(${c.peakReqPerSec.toString()})</span></td>
           <td>${c.reqPerHour.toString()} <span class="peak">(${c.peakReqPerHour.toString()})</span></td>
           <td>${c.reqPerDay.toString()} <span class="peak">(${c.peakReqPerDay.toString()})</span></td>
@@ -171,12 +172,4 @@ function formatUptime(seconds: number): string {
   if (d > 0) return `${d.toString()}d ${h.toString()}h ${m.toString()}m`;
   if (h > 0) return `${h.toString()}h ${m.toString()}m ${s.toString()}s`;
   return `${m.toString()}m ${s.toString()}s`;
-}
-
-function esc(str: string): string {
-  return str
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
 }


### PR DESCRIPTION
## Summary
- Replace two hand-rolled HTML escapers (`escapeHtml` in `src/broker/router.ts` and `esc` in `src/status/page.ts`) with the [`escape-html`](https://www.npmjs.com/package/escape-html) package — the same dependency Express's own helpers use under the hood.
- The router's previous escaper handled `& < > \" '`; the status page's escaper handled `& < > \"` only (missing `'`). `escape-html` is a strict superset of both — no XSS regression, and the status page picks up the missing single-quote escape for free.
- Adds `escape-html@^1.0.3` (prod) + `@types/escape-html@^1.0.4` (dev). Zero transitive deps.

## Context
Second of three small refactors from the closed #58. The other two are the NonceStore → lru-cache change (#75) and an SPKI helper dedupe (filed separately).

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run test` (207/207)

🤖 Generated with [Claude Code](https://claude.com/claude-code)