### PR TITLE
refactor(relay,shared): dedupe uncompressedP256ToSpki helper

### DIFF
--- a/src/relay/server.ts
+++ b/src/relay/server.ts
@@ -32,6 +32,7 @@ import {
   type Response as ResponseMessage,
   type ServerMessage,
 } from "./pb/relay_pb.js";
+import { uncompressedP256ToSpki } from "../shared/crypto.js";
 import type { ForwardResponse } from "../shared/protocol.js";
 
 // ---------------------------------------------------------------------------
@@ -507,17 +508,5 @@ export class RelayServer extends EventEmitter {
 }
 
 // ---------------------------------------------------------------------------
-// DER encoding helper
-// ---------------------------------------------------------------------------
-
-/**
- * Wraps a raw 65-byte uncompressed P-256 public key into a DER-encoded
- * SubjectPublicKeyInfo structure so Node.js crypto can import it.
- */
-function uncompressedP256ToSpki(pubkey: Buffer): Buffer {
-  const header = Buffer.from("3059301306072a8648ce3d020106082a8648ce3d030107034200", "hex");
-  return Buffer.concat([header, pubkey]);
-}
-
 // Re-export generated types for tests and external consumers.
 export type { Request, Response } from "./pb/relay_pb.js";

--- a/src/shared/crypto.ts
+++ b/src/shared/crypto.ts
@@ -77,9 +77,12 @@ export function buildSignedPayload(
 /**
  * Wraps a raw 65-byte uncompressed P-256 public key into a DER SubjectPublicKeyInfo.
  * Required by Node.js crypto to import raw EC keys.
+ *
+ * The 27-byte header is the fixed SPKI prefix for `ecPublicKey + prime256v1`.
+ * Part of the wire contract with the Go daemon — do not replace with an
+ * external package without re-verifying byte layout.
  */
-function uncompressedP256ToSpki(pubkey: Buffer): Buffer {
-  // Fixed 27-byte SPKI header for ecPublicKey + prime256v1
+export function uncompressedP256ToSpki(pubkey: Buffer): Buffer {
   const header = Buffer.from("3059301306072a8648ce3d020106082a8648ce3d030107034200", "hex");
   return Buffer.concat([header, pubkey]);
 }


### PR DESCRIPTION
## Summary
- Both `src/shared/crypto.ts:81` and `src/relay/server.ts:517` carried byte-identical copies of `uncompressedP256ToSpki` (the 27-byte DER SPKI prefix for `ecPublicKey + prime256v1`).
- Export the canonical helper from `src/shared/crypto.ts` (where its sibling `verifyECDSA` already lives) and import it from `src/relay/server.ts`. Deletes the local copy and its section header.
- Crypto duplication is a footgun: a future tweak to the byte layout has to land in two places, and divergence produces silent verify failures with no compile-time signal. One canonical home eliminates that risk.
- The 27-byte SPKI header is part of the wire contract with the Go daemon; documented inline.

## Context
Third of three small refactors from the closed #58. Companions: #75 (NonceStore -> lru-cache), #76 (HTML escaping -> escape-html package).

When #58 was filed `src/shared/crypto.ts` didn't yet exist; the original PR proposed creating a new `src/shared/crypto-utils.ts`. Since then \`shared/\` was introduced organically and \`crypto.ts\` already owns one copy of the helper, so the cleanest landing is to export the existing copy rather than introduce a third file.

## Test plan
- [x] \`npm run typecheck\`
- [x] \`npm run lint\`
- [x] \`npm run format:check\`
- [x] \`npm run test\` (207/207)

🤖 Generated with [Claude Code](https://claude.com/claude-code)